### PR TITLE
Add native GitHub "Sponsor" button linking to Patreon and Liberapay accounts

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+patreon: ultralisp
+liberapay: Ultralisp.org


### PR DESCRIPTION
Simply merge this pull request and activate the "Sponsorships" option in Ultralisp's project settings to get a cute little "Sponsor" button linking to your [Patreon](https://www.patreon.com/ultralisp) and [Liberapay](https://liberapay.com/Ultralisp.org) accounts!

Here's a [preview](https://github.com/Hexstream/ultralisp) of the end result.

Here's the [official documentation](https://help.github.com/en/articles/displaying-a-sponsor-button-in-your-repository) for this nice feature.

(Note that you do not need to be sponsored by GitHub to use this feature.)