### PR TITLE
Move to Quickdist 0.16.1 where fixed processing of systems with (:require :implementation-specific-module)

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,15 @@
  ChangeLog
 ===========
 
+1.2.4 (2021-03-04)
+==================
+
+* Move to Quickdist 0.16.1 where fixed processing of systems with
+  ``(:require :implementation-specific-module)``.
+
+  This should fix build of systems like Serapeum:
+  https://github.com/ultralisp/ultralisp/issues/101
+
 1.2.3 (2021-03-03)
 ==================
 

--- a/qlfile
+++ b/qlfile
@@ -1,6 +1,6 @@
 dist ultralisp http://dist.ultralisp.org/
 
-github quickdist ultralisp/quickdist :tag v0.16.0
+github quickdist ultralisp/quickdist :tag v0.16.1
 
 # github slynk joaotavora/sly
 github slynk-named-readtables joaotavora/sly-named-readtables

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -5,11 +5,11 @@
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org/" :%version :latest)
-  :version "20210302211500"))
+  :version "20210304205000"))
 ("quickdist" .
  (:class qlot/source/github:source-github
-  :initargs (:repos "ultralisp/quickdist" :ref nil :branch nil :tag "v0.16.0")
-  :version "github-be76e126b0cb3ff3fa60d2bf129032f8"))
+  :initargs (:repos "ultralisp/quickdist" :ref nil :branch nil :tag "v0.16.1")
+  :version "github-c9cf318e1a6dc4a6bc267335c9f276fc"))
 ("slynk-named-readtables" .
  (:class qlot/source/github:source-github
   :initargs (:repos "joaotavora/sly-named-readtables" :ref nil :branch nil :tag nil)


### PR DESCRIPTION
This should fix build of systems like Serapeum:
https://github.com/ultralisp/ultralisp/issues/101