### PR TITLE
Fix Lisp symbol indexer

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,12 @@
  ChangeLog
 ===========
 
+Unreleased (2021-03-06)
+=======================
+
+* Fixed repeating of search results after a click to the "Load more" link.
+  This closed issue https://github.com/ultralisp/ultralisp/issues/88
+
 1.3.0 (2021-03-05)
 ==================
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,9 +2,10 @@
  ChangeLog
 ===========
 
-Unreleased (2021-03-06)
+1.4.0 (2021-03-06)
 =======================
 
+* Fixed Lisp symbol indexer.
 * Fixed repeating of search results after a click to the "Load more" link.
   This closed issue https://github.com/ultralisp/ultralisp/issues/88
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,6 @@ RUN qlot exec ros build \
 RUN qlot exec ros build \
     /app/roswell/ultralisp-server.ros && \
     mv /app/roswell/ultralisp-server /app/ultralisp-server
-RUN qlot exec ros run \
-    --eval '(asdf:make :packages-extractor)' && \
-    mv /app/src/packages-extractor /app/packages-extractor
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 CMD ["/app/docker/entrypoint.sh"]

--- a/Lakefile
+++ b/Lakefile
@@ -6,7 +6,7 @@
                           :directory))
 (in-package :lake.user)
 
-(use-syntax :interpol)
+(named-readtables:in-readtable :interpol-syntax)
 
 
 (defun search-version-in-changelog (lines)
@@ -107,7 +107,14 @@
       (sh "qlot exec sblint ultralisp.asd ultralisp-test.asd"))
 
 (task "stop" ()
-      (sh "docker stop ultralisp_app ultralisp_worker ultralisp_empty_db ultralisp_elastic ultralisp_db"))
+  (loop for container in '("ultralisp_app"
+                           "ultralisp_worker"
+                           "ultralisp_empty_db"
+                           "ultralisp_elastic"
+                           "ultralisp_db"
+                           "ultralisp_gearman")
+            do (ignore-errors
+                (sh #?"docker stop ${container}"))))
 
 (task "default" ("devserver")
       ())

--- a/db/migrations/20210306000000.up.sql
+++ b/db/migrations/20210306000000.up.sql
@@ -10,7 +10,7 @@ IF id IN (SELECT project2.id FROM project2)
 THEN RETURN true;
 ELSE RETURN false;
 END IF;
-END;
+END
 $$ LANGUAGE PLpgSQL;
 
 ALTER TABLE "project_index" DROP CONSTRAINT "project_index_project_id_fkey";

--- a/db/migrations/20210306000000.up.sql
+++ b/db/migrations/20210306000000.up.sql
@@ -1,0 +1,18 @@
+DROP INDEX "unique_project_index_project_id";
+
+DELETE FROM "project_index";
+
+CREATE OR REPLACE FUNCTION project_exists(id BIGINT)
+RETURNS BOOLEAN AS
+$$
+BEGIN
+IF id IN (SELECT project2.id FROM project2)
+THEN RETURN true;
+ELSE RETURN false;
+END IF;
+END;
+$$ LANGUAGE PLpgSQL;
+
+ALTER TABLE "project_index" DROP CONSTRAINT "project_index_project_id_fkey";
+
+ALTER TABLE "project_index" ADD  CONSTRAINT "project_index_project_id_fkey" CHECK (project_exists(project_id));

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -86,9 +86,20 @@ CREATE UNIQUE INDEX "unique_social_profile_user_id_service_service_user_id" ON "
 
 create type index_status as enum ('ok', 'failed');
 
+CREATE OR REPLACE FUNCTION project_exists(id BIGINT)
+RETURNS BOOLEAN AS
+$$
+BEGIN
+IF id IN (SELECT project2.id FROM project2)
+THEN RETURN true;
+ELSE RETURN false;
+END IF;
+END;
+$$ LANGUAGE PLpgSQL;
+
 create table "project_index" (
        "id" bigserial not null primary key,
-       "project_id" bigint not null references project (id),
+       "project_id" bigint not null,
        "total_time" bigint not null default 0,
        "last_update_at" timestamptz,
        "next_update_at" timestamptz,
@@ -96,6 +107,8 @@ create table "project_index" (
 );
 
 create unique index "unique_project_index_project_id" ON "project_index" ("project_id");
+
+ALTER TABLE "project_index" ADD  CONSTRAINT "project_index_project_id_fkey" CHECK (project_exists(project_id));
 
 
 CREATE TABLE "project2" (

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -94,7 +94,7 @@ IF id IN (SELECT project2.id FROM project2)
 THEN RETURN true;
 ELSE RETURN false;
 END IF;
-END;
+END
 $$ LANGUAGE PLpgSQL;
 
 create table "project_index" (

--- a/src/logging.lisp
+++ b/src/logging.lisp
@@ -33,13 +33,15 @@
   (setf log4cl-extras/error:*max-traceback-depth*
         *max-depth*)
   
-  (log4cl-extras/config:setup
-    `(:level ,level
-      :appenders ((this-console :layout :plain)
-                  (daily :layout :json
-                         :name-format ,(format nil "~A/~A.log"
-                                               (or *log-dir*
-                                                   "/tmp")
-                                               app)
-                         :backup-name-format ,(format nil "~A-%Y%m%d.log"
-                                                      app))))))
+  (let ((filename (format nil "~A/~A.log"
+                          (or *log-dir*
+                              "/tmp")
+                          app))
+        (backup-filename (format nil "~A-%Y%m%d.log"
+                                 app)))
+    (log4cl-extras/config:setup
+     `(:level ,level
+       :appenders ((this-console :layout :plain)
+                   (daily :layout :json
+                          :name-format ,filename
+                          :backup-name-format ,backup-filename))))))

--- a/src/models/project.lisp
+++ b/src/models/project.lisp
@@ -126,7 +126,8 @@
    #:source->project
    #:project-url
    #:turn-off-project2
-   #:get-projects2-by-username))
+   #:get-projects2-by-username
+   #:get-projects-with-sources))
 (in-package ultralisp/models/project)
 
 
@@ -353,6 +354,21 @@
       (select-dao 'project
         (where :enabled))
       (select-dao 'project)))
+
+(defun get-projects-with-sources ()
+  "Returns projects with not deleted sources."
+  (mito.dao:select-by-sql 'project2
+                          "
+    WITH projects_with_sources AS (
+      SELECT distinct source.project_id
+        FROM source
+       WHERE latest = true
+         AND deleted = false
+    )
+    SELECT *
+      FROM project2
+     WHERE id IN (SELECT * FROM projects_with_sources)
+       AND latest = true"))
 
 
 (defun get-recent-projects (&key (limit 10))

--- a/src/models/source.lisp
+++ b/src/models/source.lisp
@@ -65,7 +65,8 @@
    #:create-source
    #:params-from-github
    #:get-current-branch
-   #:enable-this-source-version))
+   #:enable-this-source-version
+   #:params-to-string))
 (in-package ultralisp/models/source)
 
 
@@ -184,7 +185,7 @@
   (deleted-p (source obj)))
 
 
-(defun params-to-string (source)
+(defun params-to-string (source &key (last-seen t))
   (let ((type (source-type source)))
     (if (eql type :github)
         (let ((params (source-params source)))
@@ -192,7 +193,10 @@
                   (string-downcase type)
                   (getf params :user-or-org)
                   (getf params :project)
-                  (getf params :last-seen-commit)))
+                  (if last-seen
+                      (getf params :last-seen-commit)
+                      (or (getf params :branch)
+                          "master"))))
         (format nil "~A://unsupported-source-type"
                 (string-downcase type)))))
 

--- a/src/packages-extractor-api.lisp
+++ b/src/packages-extractor-api.lisp
@@ -32,77 +32,57 @@
             collect (list :system system-name
                           :packages packages))))
 
-(defun get-packages-orig (system-names &key (extractor-binary-path "/app/packages-extractor"))
-  "External function to use in other Ultralisp code.
-   Runs packages extractor in a separate process which
-   does not have any dependencies and is able to
-   load a system from scratch."
-  (let* ((system-names (uiop:ensure-list system-names))
-         (command (format nil "qlot exec ~A~{ ~A~}"
-                          extractor-binary-path
-                          system-names)))
-    (uiop:with-current-directory ("/app")
-      (handler-case
-          (with-fields (:systems system-names)
-            (with-log-unhandled ()
-              (parse-packages-output
-               (with-output-to-string (output)
-                 (with-output-to-string (error-output)
-                   (handler-bind ((uiop:subprocess-error
-                                    (lambda (c)
-                                      (let ((exit-code (uiop:subprocess-error-code c))
-                                            (command (uiop:subprocess-error-command c))
-                                            (output (get-output-stream-string
-                                                     output))
-                                            (error-output (get-output-stream-string
-                                                           error-output)))
-                                        (log:error "packages-extractor returned"
-                                                   exit-code
-                                                   command
-                                                   output
-                                                   error-output)))))
-                     (uiop:run-program command
-                                   :output output
-                                   :error error-output)))))))
-        ;; In any case we just log error and return nothing
-        (uiop/run-program:subprocess-error ())))))
 
-(defcached get-packages (system-names &key (extractor-binary-path "/app/packages-extractor")
-                                      (work-dir "/app"))
-  "External function to use in other Ultralisp code.
-   Runs packages extractor in a separate process which
-   does not have any dependencies and is able to
-   load a system from scratch."
+(defcached (get-packages :timeout 30) (system-names &key
+                                                    (work-dir "/app"))
+  "
+  External function to use in other Ultralisp code.
+  Runs packages extractor in a separate process which
+  does not have any dependencies and is able to
+  load a system from scratch.
+
+  Returns a list of lists where each sublist is a plist:
+
+      ((:SYSTEM \"jonathan\" :PACKAGES
+        (\"JONATHAN\" \"JONATHAN.HELPER\" \"JONATHAN.DECODE\" \"JONATHAN.ENCODE\"
+         \"JONATHAN.UTIL\" \"JONATHAN.ERROR\")))
+
+  "
   (log:info "Getting packages for" system-names)
   (let* ((system-names (uiop:ensure-list system-names))
-         (command (format nil "qlot exec ~A~{ ~A~}"
-                          extractor-binary-path
-                          system-names)))
-    (uiop:with-current-directory (work-dir)
-      (log:info "Calling" command work-dir)
-      (handler-case
-          (with-fields (:systems system-names)
-            (with-log-unhandled ()
-              (let (response)
-                (with-output-to-string (output)
-                  (with-output-to-string (error-output)
-                    (handler-bind ((uiop:subprocess-error
-                                     (lambda (c)
-                                       (let ((exit-code (uiop:subprocess-error-code c))
-                                             (command (uiop:subprocess-error-command c))
-                                             (output (get-output-stream-string
-                                                      output))
-                                             (error-output (get-output-stream-string
-                                                            error-output)))
-                                         (log:error "packages-extractor returned"
-                                                    exit-code
-                                                    command
-                                                    output
-                                                    error-output)))))
-                      (uiop:run-program command
-                                        :output output
-                                        :error error-output)
-                      (setf response (get-output-stream-string output)))))
-                (parse-packages-output response))))
-        ;; In any case we just log error and return nothing
-        (uiop/run-program:subprocess-error ())))))
+         (ultralisp-path (uiop:merge-pathnames*
+                          "../"
+                          (asdf:component-pathname
+                           (asdf:find-system :ultralisp))))
+         (command (format nil "qlot exec ros run --eval '(push \"~A\" asdf:*central-registry*)' --system ultralisp/packages-extractor --eval '(ultralisp/packages-extractor::inner-main~{ ~A~})' --quit"
+                          ultralisp-path
+                          (loop for name in system-names
+                                collect (format nil
+                                                "\"~A\""
+                                                (string-downcase name)))))
+         (result nil))
+    (with-fields (:command command)
+      (uiop:with-current-directory (work-dir)
+        (with-output-to-string (output)
+          (with-output-to-string (error-output)
+            (handler-case
+                (with-fields (:systems system-names)
+                  (with-log-unhandled ()
+                    (uiop:run-program command
+                                      :output output
+                                      :error-output error-output)
+                    (setf result
+                          (parse-packages-output
+                           (get-output-stream-string output)))))
+              ;; In any case we just log error and return nothing
+              (uiop/run-program:subprocess-error (c)
+                (let ((exit-code (uiop:subprocess-error-code c))
+                      (output (get-output-stream-string
+                               output))
+                      (error-output (get-output-stream-string
+                                     error-output)))
+                  (with-fields (:exit-code exit-code
+                                :output output
+                                :error-output error-output)
+                    (log:error "Packages extractor returned error")))))))))
+    (values result)))

--- a/src/search.lisp
+++ b/src/search.lisp
@@ -128,7 +128,7 @@
                                         (search-objects term
                                                         :from (+ from (length results))))))))
     (dexador.error:http-request-not-found ()
-      nil)
+      (values nil 0 nil))
     (dexador.error:http-request-bad-request (condition)
       (error 'bad-query :original-error condition))))
 

--- a/src/search.lisp
+++ b/src/search.lisp
@@ -15,6 +15,11 @@
                 #:downloaded-project-path
                 #:download)
   (:import-from #:ultralisp/models/project
+                #:project-name
+                #:get-projects-with-sources
+                #:get-project2
+                #:project-sources
+                #:project2
                 #:get-recently-updated-projects
                 #:get-all-projects
                 #:get-github-project)
@@ -34,6 +39,8 @@
   (:import-from #:local-time
                 #:timestamp-difference
                 #:now)
+  (:import-from #:ultralisp/models/source
+                #:source-systems-info)
   (:export
    #:search-objects
    #:bad-query
@@ -44,6 +51,7 @@
 (defvar *current-system-name* nil)
 (defvar *current-package-name* nil)
 (defvar *current-project-name* nil)
+(defvar *current-source-uri* nil)
 (defvar *current-system-path* nil)
 
 
@@ -76,7 +84,6 @@
 (defun search-objects (term &key (from 0))
   ;; TODO: научиться обрабатывать 400 ответы от Elastic
   ;; например на запрос: TYPE:macro AND storage NAME:FLEXI-STREAMS:WITH-OUTPUT-TO-SEQUENCE
-  (log:info "Searching by" term)
   (handler-case
       (loop with url = (fmt "http://~A:9200/symbols/_search"
                             (get-elastic-host))
@@ -88,10 +95,10 @@
                                           :|query| term))
                           :|from| from)
             with content = (jonathan:to-json query)
-            with response = (jonathan:parse
-                             (dex:post url
-                                       :content content
-                                       :headers '(("Content-Type" . "application/json"))))
+            with body = (dex:post url
+                                  :content content
+                                  :headers '(("Content-Type" . "application/json")))
+            with response = (jonathan:parse body)
             with total = (getf (getf (getf response
                                            :|hits|)
                                      :|total|)
@@ -124,9 +131,10 @@
                                     total
                                     (when (< (+ from (length results))
                                              total)
-                                      (lambda ()
-                                        (search-objects term
-                                                        :from (+ from (length results))))))))
+                                      (let ((new-from (+ from (length results))))
+                                        (lambda ()
+                                          (search-objects term
+                                                          :from new-from)))))))
     (dexador.error:http-request-not-found ()
       (values nil 0 nil))
     (dexador.error:http-request-bad-request (condition)
@@ -239,6 +247,9 @@ default values from the arglist."
    
    (when *current-project-name*
      (list :|project| (string-downcase *current-project-name*)))
+
+   (when *current-source-uri*
+     (list :|source| (string-downcase *current-source-uri*)))
    
    (when *current-package-name*
      (list :|package| (string-downcase *current-package-name*)))
@@ -374,6 +385,9 @@ default values from the arglist."
 
 
 (defun index-symbols (package)
+  "
+  Returns number of indexed symbols or 0.
+  "
   ;; TODO: remove current-system-path
   (let* ((*current-system-path* (ql:where-is-system *current-system-name*))
          (current-package (etypecase package
@@ -381,32 +395,45 @@ default values from the arglist."
                             (keyword (find-package package))
                             (package package)))
          (*current-package-name* (when current-package
-                                   (package-name current-package))))
+                                   (package-name current-package)))
+         (indexed-symbols 0))
     (cond
       (current-package
        (do-external-symbols (symbol current-package)
          (let ((external (is-external symbol current-package)))
            (when external
              (let* ((full-symbol-name (encode-symbol symbol))
-                    (object-id (if *current-project-name*
-                                   (fmt "~A:~A" *current-project-name* full-symbol-name)
-                                   full-symbol-name)))
+                    (object-id (cond (*current-source-uri*
+                                      (fmt "src:~A:~A" *current-source-uri* full-symbol-name))
+                                     (*current-project-name*
+                                      (fmt "prj:~A:~A" *current-project-name* full-symbol-name))
+                                     (t
+                                      full-symbol-name)))
+                    (indexed nil))
                (when (symbol-function-type symbol)
                  (index "symbols"
                         object-id
                         (get-function-documentation symbol
-                                                    (symbol-function-type symbol))))
+                                                    (symbol-function-type symbol)))
+                 (setf indexed t))
              
                (when (class-p symbol)
                  (index "symbols"
                         object-id
-                        (get-value-documentation symbol 'type)))
+                        (get-value-documentation symbol 'type))
+                 (setf indexed t))
              
                (when (variable-p symbol)
                  (index "symbols"
                         object-id
-                        (get-value-documentation symbol 'variable))))))))
-      (t (log:error "Unable to find package" package)))))
+                        (get-value-documentation symbol 'variable))
+                 (setf indexed t))
+
+               (when indexed
+                 (incf indexed-symbols)))))))
+      (t (log:error "Unable to find package" package)))
+
+    (values indexed-symbols)))
 
 
 (defun index-all-packages ()
@@ -455,85 +482,119 @@ default values from the arglist."
          (ql:quickload system))))))
 
 
-(defun index-project (project)
-  "This function should be called inside the worker."
-  (declare (ignore project))
-  ;; TODO: reimplement for project2
-  ;; (let* ((path (downloaded-project-path
-  ;;               (download project "/tmp/indexer" :latest t))))
+(defun index-source (project source &key (clear-dir t))
+  "
+  This function should be called inside the worker.
 
-  ;;   (unwind-protect
-  ;;        (uiop:with-current-directory (path)
-  ;;          (log:info "Working in" path)
-  ;;          ;; Prepare qlfile and install the dependencies
-  ;;          (alexandria:with-output-to-file (s (merge-pathnames #P"qlfile"
-  ;;                                                              path)
-  ;;                                             :if-exists :supersede)
-  ;;            (format s "dist ultralisp http://dist.ultralisp.org/~%")
-  ;;            (let ((lock-file (probe-file (merge-pathnames #P"qlfile.lock"
-  ;;                                                          path))))
-  ;;              (when lock-file
-  ;;                (delete-file lock-file)))
-  ;;            (qlot/install:install-project path :install-deps nil))
+  Returns a number of indexed symbols.
+  "
+  (check-type project project2)
+  (check-type source ultralisp/models/source:source)
+  
+  (let* ((path (downloaded-project-path
+                (download source "/tmp/indexer" :latest t)))
+         (qlfile-path (merge-pathnames #P"qlfile"
+                                       path))
+         (indexed-symbols 0))
 
-  ;;          (log:info "Entering local quicklisp")
-  ;;          (qlot:with-local-quicklisp (path)
-  ;;            (loop with systems = (ultralisp/models/project:get-systems-info project)
-  ;;                  with *current-project-name* = (ultralisp/models/project:get-name project)
-  ;;                  with asdf:*central-registry* = (cons path asdf:*central-registry*)
-  ;;                  for system in systems
-  ;;                  do (log:info "Checking system" system)
-  ;;                     (let ((data (get-packages (quickdist:get-name system)
-  ;;                                               :work-dir path)))
-  ;;                       (log:info "Indexing system" system data)
-  ;;                       (loop for item in data
-  ;;                             for *current-system-name* = (getf item :system)
-  ;;                             for packages = (getf item :packages)
-  ;;                             do (when (safe-quickload *current-system-name*)
-  ;;                                  (let ((*current-system-path* (ql:where-is-system *current-system-name*)))
-  ;;                                    (loop for package in packages
-  ;;                                          do (log:info "Indexing package" package)
-  ;;                                             (index-symbols package)))))))))
-  ;;     ;; Here we need to make a clean up to not clutter the file system
-  ;;     (log:info "Deleting checked out" path)
-  ;;     (uiop:delete-directory-tree path
-  ;;                                 :validate t)))
-  )
+    (unwind-protect
+         (uiop:with-current-directory (path)
+           (log:info "Working in" path)
+           ;; Prepare qlfile and install the dependencies
+           (cond
+             ;; If qlfile already exists, we'll use it
+             ((probe-file qlfile-path)
+              nil)
+             ;; Otherwise we'll create a new one
+             (t
+              (alexandria:with-output-to-file (s qlfile-path
+                                                 :if-exists :supersede)
+                (log:info "Creating a new qlfile")
+                (format s "dist ultralisp http://dist.ultralisp.org/
+github mgl-pax svetlyak40wt/mgl-pax :branch mgl-pax-minimal"))
+
+              ;; Just in case, we'll remove lock file:
+              (let ((lock-file (probe-file (merge-pathnames #P"qlfile.lock"
+                                                            path))))
+                (log:info "Deleting old qlfile.lock")
+                (when lock-file
+                  (delete-file lock-file)))))
+
+           ;; This will create .qlot/ folder out of qlfile
+           (qlot/install:install-project path :install-deps nil)
+
+           (log:info "Entering local quicklisp")
+           (qlot:with-local-quicklisp (path)
+             (loop with systems = (source-systems-info source)
+                   with *current-project-name* = (ultralisp/models/project:project-name project)
+                   with *current-source-uri* = (ultralisp/models/source::params-to-string
+                                                source
+                                                ;; We'll use this string as a document ID and
+                                                ;; don't want it to change on every commit.
+                                                :last-seen nil)
+                   with asdf:*central-registry* = (cons path asdf:*central-registry*)
+                   for system in systems
+                   do (log:info "Checking system" system)
+                      (let ((data (get-packages (quickdist:get-name system)
+                                                :work-dir path)))
+                        (log:info "Indexing system" system data)
+                        (loop for item in data
+                              for *current-system-name* = (getf item :system)
+                              for packages = (getf item :packages)
+                              do (when (safe-quickload *current-system-name*)
+                                   (let ((*current-system-path* (ql:where-is-system *current-system-name*)))
+                                     (loop for package in packages
+                                           do (log:info "Indexing package" package)
+                                              (incf indexed-symbols
+                                                    (index-symbols package))))))))))
+      ;; Here we need to make a clean up to not clutter the file system
+      (when clear-dir
+        (log:info "Deleting checked out" path)
+        (uiop:delete-directory-tree path
+                                    :validate t)))
+
+    (values indexed-symbols)))
+
+(defun index-project (project &key (clear-dir t))
+  "
+  This function should be called inside the worker.
+
+  Returns a number of indexed symbols.
+  "
+  (check-type project project2)
+  
+  (loop for source in (project-sources project)
+        summing (index-source project source
+                              :clear-dir clear-dir)))
 
 
 (defun index-projects (&key names force (limit 10))
-  (declare (ignore names force limit))
-  ;; TODO: reimplement for project2
-  ;; (let ((projects (cond
-  ;;                   (names
-  ;;                    (loop for name in names
-  ;;                          for splitted = (cl-strings:split name #\/)
-  ;;                          collect (get-github-project (first splitted)
-  ;;                                                      (second splitted))))
-  ;;                   ;; Reindexing all projects
-  ;;                   (force (get-all-projects :only-enabled t))
-  ;;                   ;; 
-  ;;                   (t (get-projects-to-index :limit limit)))))
-  ;;   (loop for project in projects
-  ;;         for started-at = (now)
-  ;;         do (log:info "Indexing project" project)
-  ;;            (flet ((get-total-time ()
-  ;;                     (floor (timestamp-difference
-  ;;                             (now)
-  ;;                             started-at))))
-  ;;              (handler-case
-  ;;                  (with-fields
-  ;;                      (:project-name (ultralisp/models/project:get-name project))
-  ;;                    (with-log-unhandled ()
-  ;;                      (with-transaction
-  ;;                        (submit-task
-  ;;                         'index-project project))
-  ;;                      (set-index-status project
-  ;;                                        :ok
-  ;;                                        :total-time (get-total-time))))
-  ;;                (error ()
-  ;;                  (set-index-status project
-  ;;                                    :failed
-  ;;                                    :total-time (get-total-time))))))
-  ;;   (log:info "DONE"))
-  )
+  (let ((projects (cond
+                    (names
+                     (mapcar #'get-project2 names))
+                    ;; Reindexing all projects
+                    (force (get-projects-with-sources))
+                    ;; 
+                    (t (get-projects-to-index :limit limit)))))
+    (loop for project in projects
+          for started-at = (now)
+          do (log:info "Indexing project" project)
+             (flet ((get-total-time ()
+                      (floor (timestamp-difference
+                              (now)
+                              started-at))))
+               (handler-case
+                   (with-fields
+                       (:project-name (project-name project))
+                     (with-log-unhandled ()
+                       (with-transaction
+                         (submit-task
+                          'index-project project))
+                       (set-index-status project
+                                         :ok
+                                         :total-time (get-total-time))))
+                 (error ()
+                   (set-index-status project
+                                     :failed
+                                     :total-time (get-total-time))))))
+    (log:info "DONE")))

--- a/src/search.lisp
+++ b/src/search.lisp
@@ -609,28 +609,29 @@ github mgl-pax svetlyak40wt/mgl-pax :branch mgl-pax-minimal"))
                     (t (get-projects-to-index :limit limit)))))
     (loop for project in projects
           for started-at = (now)
-          do (log:info "Indexing project" project)
-             (flet ((get-total-time ()
-                      (floor (timestamp-difference
-                              (now)
-                              started-at))))
-               (handler-case
-                   (with-fields
-                       (:project-name (project-name project))
+          for project-name = (project-name project)
+          do (with-fields (:project-name project-name)
+               (log:info "Indexing project")
+               
+               (flet ((get-total-time ()
+                        (floor (timestamp-difference
+                                (now)
+                                started-at))))
+                 (handler-case
                      (with-log-unhandled ()
                        (with-transaction
                          (submit-task
                           'index-project project))
                        (set-index-status project
                                          :ok
-                                         :total-time (get-total-time))))
-                 (error ()
-                   ;; TODO: we also set status to failed
-                   ;; when there wasn't any symbols found in the project.
-                   ;; This can be done using ultralisp/rpc/command:defcommand
-                   (set-index-status project
-                                     :failed
-                                     :total-time (get-total-time))))))
+                                         :total-time (get-total-time)))
+                   (error ()
+                     ;; TODO: we also set status to failed
+                     ;; when there wasn't any symbols found in the project.
+                     ;; This can be done using ultralisp/rpc/command:defcommand
+                     (set-index-status project
+                                       :failed
+                                       :total-time (get-total-time)))))))
     (log:info "DONE")))
 
 

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -493,10 +493,13 @@
   (loop with vars = '(("GITHUB_CLIENT_ID" "0bc769474b14267aac28")
                       ("GITHUB_SECRET" "3f46156c6bd57f4c233db9449ed556b6e545315a")
                       ("BASE_URL" "http://localhost:8081/dist/")
-                      ("CRON_DISABLED" "yes"))
+                      ("CRON_DISABLED" "yes")
+                      ("ELASTIC_SEARCH_HOST" "localhost"))
         for (name value) in vars
         do (setf (uiop/os:getenv name)
                  value))
+
+  (function-cache:clear-cache-all-function-caches)
 
   ;; For some reason default "TEMPORARY-FILES:TEMP-%" does not work on OSX:
   (setf cl-fad::*default-template*

--- a/src/widgets/search.lisp
+++ b/src/widgets/search.lisp
@@ -54,7 +54,7 @@
       (log:info "Fetching next batch of results")
       (handler-case
           (multiple-value-bind (results total next-closure)
-              (search-objects (get-query widget))
+              (funcall getter)
             (setf (get-results widget)
                   (append (get-results widget)
                           results)

--- a/src/worker.lisp
+++ b/src/worker.lisp
@@ -116,4 +116,11 @@
 (defun start-outside-docker ()
   (ultralisp/logging:setup-for-repl :level "error"
                                     :app "worker")
+  (loop with vars = '(("ELASTIC_SEARCH_HOST" "localhost"))
+        for (name value) in vars
+        do (setf (uiop/os:getenv name)
+                 value))
+
+  (function-cache:clear-cache-all-function-caches)
+  
   (process-jobs))


### PR DESCRIPTION
After the last big refactoring symbol indexer was turned off and all new projects weren't available at search.

Now indexer is fixed and all projects will be reindexed soon.

Also, this pull fixes these issues:

* https://github.com/ultralisp/ultralisp/issues/107
* https://github.com/ultralisp/ultralisp/issues/88

> I dedicate this pull to my beautiful wife and amazing children, who have generously allowed me to work on Ultralisp this Saturday.