### PR TITLE
Fixed a way how project checking and dist building processes were synchronized

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -14,6 +14,7 @@
 
   Now, the lock is taken only during a single check and dist builder
   waits it for 4 minutes to have a chance to build the dist.
+* Don't showing empty ``PENDING`` dist versions on the landing page.
 
 1.4.1 (2021-03-07)
 ==================

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,19 @@
  ChangeLog
 ===========
 
+1.4.2 (2021-03-09)
+==================
+
+* Fixed a way how project checking and dist building processes were synchronized.
+
+  Previously, a single lock was used and it was aquired by process checking the
+  sources during a long period of time. Sometimes this leads to a long periods
+  of time when the server wasn't able to build a new dist version because of
+  large amount of checks in the queue.
+
+  Now, the lock is taken only during a single check and dist builder
+  waits it for 4 minutes to have a chance to build the dist.
+
 1.4.1 (2021-03-07)
 ==================
 

--- a/src/builder.lisp
+++ b/src/builder.lisp
@@ -441,7 +441,7 @@
   "Searches and prepares a pending versions for all distributions."
   (with-transaction
     (log:info "Trying to acquire a lock performing-pending-checks-or-version-build")
-    (with-lock ("performing-pending-checks-or-version-build")
+    (with-lock ("prepare-pending-dists" :timeout (* 4 60 1000))
       (log:info "Checking if there is a version to build")
       
       (mapc #'prepare-dist
@@ -452,7 +452,7 @@
   "Searches and builds a pending versions for all distributions."
   (with-transaction
     (log:info "Trying to acquire a lock performing-pending-checks-or-version-build")
-    (with-lock ("performing-pending-checks-or-version-build")
+    (with-lock ("build-prepared-dists")
       (log:info "Checking if there is a version to build")
       
       (mapc #'build-dist

--- a/src/widgets/landing.lisp
+++ b/src/widgets/landing.lisp
@@ -171,38 +171,39 @@
          ;;              ;; (format nil "/versions/~A" number)
          ;;              )
          )
-    (with-html
-      (:tr
-       (:td :class "name-cell"
-            (:a :href dist-url
-                dist-name))
-       (:td :class "version-cell"
-            (case state
-              (:ready
-               number
-               ;; (:a :href version-uri
-               ;;     number)
-               )
-              (t (:span "No version yet"))))
-       (:td :class "timestamp-cell"
-            (if built-at
-                (:span :title (humanize-timestamp built-at)
-                       ("~A ago"
-                        (humanize-duration
-                         (timestamp-difference (now)
-                                               built-at))))
-                (symbol-name state)
+    (when bound-sources
+      (with-html
+        (:tr
+         (:td :class "name-cell"
+              (:a :href dist-url
+                  dist-name))
+         (:td :class "version-cell"
+              (case state
+                (:ready
+                 number
+                 ;; (:a :href version-uri
+                 ;;     number)
+                 )
+                (t (:span "No version yet"))))
+         (:td :class "timestamp-cell"
+              (if built-at
+                  (:span :title (humanize-timestamp built-at)
+                         ("~A ago"
+                          (humanize-duration
+                           (timestamp-difference (now)
+                                                 built-at))))
+                  (symbol-name state)
 
-                ;; "Pending"
-                )))
-      (:tr 
-       (:td :class "changelog-cell"
-            :colspan 3
-            (:ul :class "changelog"
-                 (mapc #'render-bound-source
-                       bound-sources))
-            (when has-more
-              (:p "And more...")))))))
+                  ;; "Pending"
+                  )))
+        (:tr 
+         (:td :class "changelog-cell"
+              :colspan 3
+              (:ul :class "changelog"
+                   (mapc #'render-bound-source
+                         bound-sources))
+              (when has-more
+                (:p "And more..."))))))))
 
 
 (defmethod render ((widget landing-widget))


### PR DESCRIPTION
Previously, a single lock was used and it was acquired by process checking the
sources during a long period of time. Sometimes this leads to long periods
of time when the server wasn't able to build a new dist version because of
a large amount of checks in the queue.

Now, the lock is taken only during a single check and dist builder
waits for it for 4 minutes to have a chance to build the dist.