### PR TITLE
Moved to newer Ultralisp dist where a warning was fixed

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -7,6 +7,10 @@
 
 * Removed code ``(setf dexador:*use-connection-pool* nil)``
   which caused descriptor leaks.
+* Moved to newer Ultralisp dist where this warning was fixed::
+
+      Please, switch to the ui-widget class, because widget was renamed to
+      ui-widget and will be removed after 2020-06-01.
 
 1.5.1 (2021-03-12)
 ==================

--- a/qlfile
+++ b/qlfile
@@ -2,6 +2,13 @@ dist ultralisp http://dist.ultralisp.org/
 
 github quickdist ultralisp/quickdist :tag v0.16.2
 
+# Until this issue will be resolved:
+# https://github.com/ultralisp/ultralisp/issues/73
+# Either https://ultralisp.org/projects/thodg/str or
+# https://ultralisp.org/projects/vindarel/cl-str should be disabled
+# automatically:
+ql cl-str :latest
+
 # Until https://github.com/ultralisp/ultralisp/issues/117 will be resolved
 ql ironclad :latest
 

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -10,6 +10,10 @@
  (:class qlot/source/github:source-github
   :initargs (:repos "ultralisp/quickdist" :ref nil :branch nil :tag "v0.16.2")
   :version "github-d2a61646eeb90d472b316cf4fae61359"))
+("cl-str" .
+ (:class qlot/source/ql:source-ql
+  :initargs (:%version :latest)
+  :version "ql-2021-02-28"))
 ("ironclad" .
  (:class qlot/source/ql:source-ql
   :initargs (:%version :latest)

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -5,7 +5,7 @@
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org/" :%version :latest)
-  :version "20210311205001"))
+  :version "20210312123500"))
 ("quickdist" .
  (:class qlot/source/github:source-github
   :initargs (:repos "ultralisp/quickdist" :ref nil :branch nil :tag "v0.16.2")


### PR DESCRIPTION
This warning was fixed:

    Please, switch to the ui-widget class, because widget was renamed to
    ui-widget and will be removed after 2020-06-01.