### PR TITLE
Now distribution can include only one ASDF system with given name

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,17 @@
  ChangeLog
 ===========
 
+1.8.0 (2021-03-14)
+=================
+
+* Now distribution can include only one ASDF system with given name.
+
+  Sources with conflicting ASDF systems will be disabled automatically
+  and it will be impossible add duplicating systems again.
+
+  However, you can include systems with the same name into different
+  distributions.
+
 1.7.0 (2021-03-13)
 ==================
 

--- a/db/migrations/20210313000001.up.sql
+++ b/db/migrations/20210313000001.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE "asdf_system" (
+    "dist_id" BIGINT NOT NULL,
+    "name" TEXT NOT NULL,
+    "source_id" BIGINT NOT NULL,
+    "dependencies" JSONB NOT NULL,
+    "created_at" TIMESTAMPTZ,
+    "updated_at" TIMESTAMPTZ,
+    PRIMARY KEY ("dist_id", "name")
+);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -225,6 +225,17 @@ CREATE TABLE "check2" (
     REFERENCES "source" ("id", "version")  ON DELETE CASCADE
 );
 
+
+CREATE TABLE "asdf_system" (
+    "dist_id" BIGINT NOT NULL,
+    "name" TEXT NOT NULL,
+    "source_id" BIGINT NOT NULL,
+    "dependencies" JSONB NOT NULL,
+    "created_at" TIMESTAMPTZ,
+    "updated_at" TIMESTAMPTZ,
+    PRIMARY KEY ("dist_id", "name")
+);
+
 -- how to reset project2 tables
 -- delete from project2; delete from source; delete from dist; delete from dist_source; delete from dist_moderator; delete from project_moderator; delete from check2;
 

--- a/src/models/asdf-system.lisp
+++ b/src/models/asdf-system.lisp
@@ -1,0 +1,229 @@
+(defpackage #:ultralisp/models/asdf-system
+  (:use #:cl)
+  (:import-from #:mito
+                #:object-id)
+  (:import-from #:quickdist)
+  (:import-from #:ultralisp/utils/db
+                #:inflate-json
+                #:deflate-json)
+  (:import-from #:ultralisp/models/dist
+                #:dist-name-source
+                #:source->dists)
+  (:import-from #:ultralisp/models/source
+                #:get-all-sources
+                #:source-systems-info)
+  (:import-from #:ultralisp/models/project
+                #:project-name
+                #:source->project)
+  (:import-from #:rutils
+                #:fmt)
+  (:import-from #:log4cl-extras/error
+                #:with-log-unhandled)
+  (:export
+   #:dist-id
+   #:asdf-system-name
+   #:source-id
+   #:asdf-system-dependencies
+   #:make-asdf-system
+   #:fill-database
+   #:get-conflicting-systems
+   #:asdf-system-project
+   #:remove-source-systems
+   #:asdf-systems-conflict))
+(in-package ultralisp/models/asdf-system)
+
+
+(defclass asdf-system ()
+  ((dist-id :col-type :bigint
+            :initarg :dist-id
+            :reader dist-id)
+   (name :col-type :text
+         :initarg :name
+         :reader asdf-system-name)
+   (source-id :col-type :bigint
+              :initarg :source-id
+              :reader source-id)
+   (dependencies :col-type :jsonb
+                 :initarg :dependencies
+                 :initform nil
+                 :accessor asdf-system-dependencies
+                 :deflate #'deflate-json
+                 :inflate #'inflate-json
+                 :documentation "A list of strings with ASDF system names."))
+  (:primary-key dist-id name)
+  (:metaclass mito:dao-table-class))
+
+
+(defun make-asdf-system (dist-id name source-id dependencies)
+  (mito:create-dao 'asdf-system
+                   :dist-id dist-id
+                   :name name
+                   :source-id source-id
+                   :dependencies (sort (copy-list dependencies)
+                                       #'string<)))
+
+
+(defparameter *cond* nil)
+
+(defparameter *original-cond* nil)
+
+(define-condition asdf-systems-conflict (error)
+  ((conflicts :initarg :conflicts
+              :reader asdf-systems-conflicts)
+   (dist :initarg :dist
+         :reader asdf-systems-conflicting-dist))
+  (:report (lambda (condition stream)
+             (format stream "Distribution ~S already has these ASDF systems:~%~{~A~^~%~}"
+                     (dist-name (asdf-systems-conflicting-dist condition))
+                     (loop for conflict in (asdf-systems-conflicts condition)
+                           for system-name = (asdf-system-name conflict)
+                           for project = (asdf-system-project conflict)
+                           for project-name = (project-name project)
+                           collect (fmt " - ~S in project ~S"
+                                        system-name
+                                        project-name))))))
+
+
+(defun add-source-systems (dist source)
+  (ultralisp/db:with-transaction
+    (let ((conflicts (get-conflicting-systems source :dists dist)))
+      (when conflicts
+        (error 'asdf-systems-conflict
+               :dist dist
+               :conflicts conflicts)))
+    
+    (remove-source-systems dist source)
+  
+    (loop for system-info in (source-systems-info source)
+          for system-name = (quickdist:get-name system-info)
+          for dependencies = (quickdist:get-dependencies system-info)
+          do (make-asdf-system (object-id dist)
+                               system-name
+                               (object-id source)
+                               dependencies))))
+
+
+(defun remove-source-systems (dist source)
+  (mito:execute-sql "DELETE FROM asdf_system WHERE dist_id = ? AND source_id = ?"
+                    (list (mito:object-id dist)
+                          (mito:object-id source))))
+
+
+(defmethod print-object ((obj asdf-system) stream)
+  (print-unreadable-object (obj stream :type t)
+    (format stream
+            "~12I~S~:@_source=~A~:@_dependencies=~S"
+            (asdf-system-name obj)
+            (or (ignore-errors (asdf-system-source obj))
+                "<error:unable to fetch source>")
+            (asdf-system-dependencies obj))))
+
+
+(defun asdf-system-source (system)
+  (ultralisp/models/source:get-latest-version-by-id
+   (source-id system)))
+
+(defun asdf-system-project (system)
+  (source->project
+   (asdf-system-source system)))
+
+
+(defun fill-database ()
+  "Builds a hash dist-id->system-name->source. Then fills \"asdf_system\"
+   table with this data.
+
+   Should be used manually, to fill database after migration."
+  
+  (let ((sources (get-all-sources))
+        (dist-id->dist (make-hash-table :test 'equal))
+        (dist-id->system-name->sources (make-hash-table :test 'equal)))
+    
+    (labels ((register (dists systems source)
+               (loop for dist in dists
+                     do (add-systems-to-dist dist systems source)))
+             
+             (get-dist-hash (dist)
+               (let ((dist-id (mito:object-id dist)))
+                 (unless (gethash dist-id dist-id->dist)
+                   (setf (gethash dist-id dist-id->dist)
+                         dist)
+                   (setf (gethash dist-id dist-id->system-name->sources)
+                         (make-hash-table :test 'equal)))
+                 (gethash dist-id dist-id->system-name->sources)))
+             
+             (add-systems-to-dist (dist systems source)
+               (loop with hash = (get-dist-hash dist)
+                     for system-info in systems
+                     for system-name = (quickdist:get-name system-info)
+                     do (push source
+                              (gethash system-name hash)))))
+      (loop for source in sources
+            for dists = (source->dists source :enabled t)
+            for systems = (source-systems-info source)
+            do (register dists systems source)
+            finally (progn (save-hash-to-db dist-id->system-name->sources)
+                           (return dist-id->system-name->sources))))))
+
+
+(defun save-hash-to-db (dist-id->system-name->sources)
+  (loop initially (mito:execute-sql
+                   "TRUNCATE TABLE asdf_system" )
+        for dist-id being the hash-keys of dist-id->system-name->sources
+          using (hash-value system-name->sources)
+        do (loop for system-name being the hash-keys of system-name->sources
+                   using (hash-value sources)
+                 for sorted-sources = (sort (copy-list sources)
+                                            #'local-time:timestamp<
+                                            :key #'mito:object-created-at)
+                 for source = (first sorted-sources)
+                 for source-id = (mito:object-id source)
+                 ;; Now we need to extract system's dependencies
+                 ;; from the source
+                 for source-systems = (source-systems-info source)
+                 for system-info = (find system-name source-systems
+                                         :key #'quickdist:get-name
+                                         :test #'string=)
+                 for dependencies = (quickdist:get-dependencies system-info)
+                 do (make-asdf-system dist-id
+                                      system-name
+                                      source-id
+                                      dependencies))))
+
+
+(defun get-conflicting-systems (source &key dists)
+  "Checks if this source includes some systems which already provided
+   by other sources in any of the dists to which the source is connected."
+  (let* ((source-id (mito:object-id source))
+         ;; It is important here to fetch all dists
+         ;; even if source is disabled there. Otherwise
+         ;; source will be disabled during the one check
+         ;; and enabled during the next check.
+         (dists (or (uiop:ensure-list dists)
+                    (source->dists source)))
+         (dist-ids (mapcar #'mito:object-id
+                           dists))
+         (systems (source-systems-info source))
+         (system-names (mapcar #'quickdist:get-name
+                               systems)))
+    (when (and dist-ids
+               system-names)
+      (mito:select-dao 'asdf-system
+        (sxql:where (:and (:in 'dist-id
+                               dist-ids)
+                          (:in 'name
+                               system-names)
+                          (:!= 'source-id
+                               source-id)))))))
+
+
+(defun show-conflicts ()
+  "Returns a list of lists.
+   Each item is a plist like:
+
+   (:source <source> :conflicts (<conflicting-asdf-system1> ...))
+  "
+  (loop for source in (get-all-sources)
+        for conflicts = (get-conflicting-systems source)
+        when conflicts
+          collect (list :source source
+                        :conflicts conflicts)))

--- a/src/models/asdf-system.lisp
+++ b/src/models/asdf-system.lisp
@@ -6,8 +6,8 @@
   (:import-from #:ultralisp/utils/db
                 #:inflate-json
                 #:deflate-json)
-  (:import-from #:ultralisp/models/dist
-                #:dist-name-source
+  (:import-from #:ultralisp/models/dist-source
+                #:dist-name
                 #:source->dists)
   (:import-from #:ultralisp/models/source
                 #:get-all-sources

--- a/src/models/check.lisp
+++ b/src/models/check.lisp
@@ -70,7 +70,8 @@
    #:get-last-source-check
    #:get-check2-by-id
    #:check2
-   #:position-in-the-queue))
+   #:position-in-the-queue
+   #:get-latest-source-checks))
 (in-package ultralisp/models/check)
 
 
@@ -426,14 +427,19 @@ SELECT position
               source))))
 
 
+(defun get-latest-source-checks (source &key (limit 10))
+  (check-type source ultralisp/models/source:source)
+  (select-dao 'check2
+    (where (:= 'source-id (mito:object-id source)))
+    (order-by (:desc 'processed-at)
+              (:desc 'created-at))
+    (limit limit)))
+
+
 (defun get-last-source-check (source)
   (check-type source ultralisp/models/source:source)
   (first
-   (select-dao 'check2
-     (where (:= 'source-id (mito:object-id source)))
-     (order-by (:desc 'processed-at)
-               (:desc 'created-at))
-     (limit 1))))
+   (get-latest-source-checks source :limit 1)))
 
 
 (defun get-last-project-checks (project)

--- a/src/models/source.lisp
+++ b/src/models/source.lisp
@@ -69,7 +69,8 @@
    #:get-current-branch
    #:enable-this-source-version
    #:params-to-string
-   #:ignore-dirs))
+   #:ignore-dirs
+   #:get-latest-version-by-id))
 (in-package ultralisp/models/source)
 
 
@@ -468,3 +469,10 @@
               do (set-default-branch source))))
 
     (format t "Done.~%")))
+
+
+(defun get-latest-version-by-id (source-id)
+  (assert source-id)
+  (mito:find-dao 'source
+                 :id source-id
+                 :latest "true"))

--- a/src/models/versioned.lisp
+++ b/src/models/versioned.lisp
@@ -5,6 +5,8 @@
   (:import-from #:rutils
                 #:fmt)
   (:export
+   #:id
+   #:version
    #:object-id
    #:object-version
    #:latest-p

--- a/src/server.lisp
+++ b/src/server.lisp
@@ -77,6 +77,7 @@
                 #:defcached)
   (:import-from #:ultralisp/models/project
                 #:get-all-projects)
+  (:import-from #:ultralisp/models/asdf-system)
   (:import-from #:weblocks/error-handler
                 #:on-error)
 

--- a/src/utils/http.lisp
+++ b/src/utils/http.lisp
@@ -7,8 +7,9 @@
 (in-package ultralisp/utils/http)
 
 
-(defun get-json (url)
+(defun get-json (url &key headers)
   (jonathan:parse
    (dex:get url
             :connect-timeout 3
-            :read-timeout 3)))
+            :read-timeout 3
+            :headers headers)))


### PR DESCRIPTION
Sources with conflicting ASDF systems will be disabled automatically
and it will be impossible add duplicating systems again.

However, you can include systems with the same name into different
distributions.

This pull is sponsored by Russian Winter:

![9384](https://user-images.githubusercontent.com/24827/111070358-79733200-84e2-11eb-9811-faa4b17dd5c4.jpg)
