### PR TITLE
Fixed the case when worker wasn't able to finish project indexer beca…

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,17 @@
  ChangeLog
 ===========
 
+1.8.2 (2021-03-20)
+==================
+
+* Fixed the case when worker wasn't able to finish project
+  indexer because it was each time killed by OOM killer.
+  
+  Now the indexer will wait for 5 minutes and remove the job
+  from the Gearman server.
+* Also, Prometheus metrics were added to show number
+  of indexed projects and a number of fails.
+
 1.8.1 (2021-03-17)
 ==================
 

--- a/db/migrations/20210320000001.up.sql
+++ b/db/migrations/20210320000001.up.sql
@@ -1,0 +1,1 @@
+alter table project_index add column num_tries integer default 0;

--- a/db/migrations/20210320000002.up.sql
+++ b/db/migrations/20210320000002.up.sql
@@ -1,0 +1,4 @@
+COMMIT;
+
+ALTER TYPE "index_status" ADD VALUE IF NOT EXISTS 'timeout';
+

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -84,7 +84,7 @@ CREATE TABLE "social_profile" (
 );
 CREATE UNIQUE INDEX "unique_social_profile_user_id_service_service_user_id" ON "social_profile" ("user_id", "service", "service_user_id");
 
-create type index_status as enum ('ok', 'failed');
+create type index_status as enum ('ok', 'failed', 'timeout');
 
 CREATE OR REPLACE FUNCTION project_exists(id BIGINT)
 RETURNS BOOLEAN AS
@@ -103,6 +103,7 @@ create table "project_index" (
        "total_time" bigint not null default 0,
        "last_update_at" timestamptz,
        "next_update_at" timestamptz,
+       "num_tries" integer default 0,
        "status" index_status
 );
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     container_name: ultralisp_gearman
     # https://hub.docker.com/r/artefactual/gearmand/dockerfile
     # https://github.com/artefactual-labs/docker-gearmand
-    image: "artefactual/gearmand:1.1.18-alpine"
+    image: "artefactual/gearmand:1.1.19.1-alpine"
     ports:
       - "127.0.0.1:4730:4730"
 

--- a/qlfile
+++ b/qlfile
@@ -18,14 +18,15 @@ github slynk-named-readtables joaotavora/sly-named-readtables
 # To make log4slime work also for SLY
 # github log4cl 40ants/log4cl :branch support-sly
 
-# github mgl-pax svetlyak40wt/mgl-pax :branch mgl-pax-minimal
-
 # Unless pull merged
 github mgl-pax svetlyak40wt/mgl-pax :branch mgl-pax-minimal
 
 # This branch is what I use in my Emacs.
 github slynk svetlyak40wt/sly :branch patches
 
+
+# Here I've fixed error and timeout processing:
+github cl-gearman svetlyak40wt/cl-gearman :branch patches
 
 # Because bug in constant definition:
 # https://github.com/ultralisp/ultralisp/issues/84

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -5,7 +5,7 @@
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org/" :%version :latest)
-  :version "20210312123500"))
+  :version "20210320152838"))
 ("quickdist" .
  (:class qlot/source/github:source-github
   :initargs (:repos "ultralisp/quickdist" :ref nil :branch nil :tag "v0.16.2")
@@ -30,6 +30,10 @@
  (:class qlot/source/github:source-github
   :initargs (:repos "svetlyak40wt/sly" :ref nil :branch "patches" :tag nil)
   :version "github-62eaa8112b926b328a9838e7d5b21c15"))
+("cl-gearman" .
+ (:class qlot/source/github:source-github
+  :initargs (:repos "svetlyak40wt/cl-gearman" :ref nil :branch "patches" :tag nil)
+  :version "github-b0e841df3ed1869d1e069b5a1651af71"))
 ("bordeaux-threads" .
  (:class qlot/source/github:source-github
   :initargs (:repos "sionescu/bordeaux-threads" :ref "61e6e5645848e77367775610e4537043ea810f6d" :branch nil :tag nil)

--- a/src/builder.lisp
+++ b/src/builder.lisp
@@ -359,11 +359,11 @@
 ;; TODO: remove after migration 
 (defun prepare-pending-version ()
   (with-transaction
-    (log:info "Trying to acquire a lock performing-pending-checks-or-version-build from prepare pending version")
+    (log:warn "TRACE: Trying to acquire a lock performing-pending-checks-or-version-build from prepare pending version to prepare pending version 1")
     (with-lock ("performing-pending-checks-or-version-build")
       (let ((version (get-pending-version)))
         (when version
-          (log:info "Preparing version for build" version)
+          (log:warn "TRACE: Preparing version for build" version)
           (create-projects-snapshots-for version)
           (setf (get-type version)
                 :prepared)
@@ -373,9 +373,9 @@
 (defun build-prepared-versions ()
   "Searches and builds a pending version if any."
   (with-transaction
-    (log:info "Trying to acquire a lock performing-pending-checks-or-version-build")
+    (log:warn "TRACE: Trying to acquire a lock performing-pending-checks-or-version-build to build prepare version 1")
     (with-lock ("performing-pending-checks-or-version-build")
-      (log:info "Checking if there is a version to build")
+      (log:warn "TRACE: Checking if there is a version to build")
       
       (loop for version in (get-prepared-versions)
             do (build-version version)))))
@@ -440,7 +440,7 @@
 (defun prepare-pending-dists ()
   "Searches and prepares a pending versions for all distributions."
   (with-transaction
-    (log:info "Trying to acquire a lock performing-pending-checks-or-version-build")
+    (log:info "Trying to acquire a lock performing-pending-checks")
     (with-lock ("prepare-pending-dists" :timeout (* 4 60 1000))
       (log:info "Checking if there is a version to build")
       
@@ -451,7 +451,7 @@
 (defun build-prepared-dists ()
   "Searches and builds a pending versions for all distributions."
   (with-transaction
-    (log:info "Trying to acquire a lock performing-pending-checks-or-version-build")
+    (log:info "Trying to acquire a lock performing-pending-checks")
     (with-lock ("build-prepared-dists")
       (log:info "Checking if there is a version to build")
       

--- a/src/cron.lisp
+++ b/src/cron.lisp
@@ -158,7 +158,8 @@
   (log:info "Trying to index projects")
   (with-lock ("indexing-projects")
     (log:info "Log aquired")
-    (ultralisp/search:index-projects :limit 1)
+    ;; TODO: Remove ultralisp from the list
+    (ultralisp/search:index-projects :limit 1 :names '("ultralisp/ultralisp"))
     (log:info "Task is done")))
 
 

--- a/src/logging.lisp
+++ b/src/logging.lisp
@@ -15,7 +15,9 @@
 (defparameter *max-depth* 100)
 
 
-(defun setup (log-dir &key (level :error))
+(defun setup (log-dir &key
+                        (level :error)
+                        (app "app"))
   (setf *log-dir* log-dir)
 
   (setf log4cl-extras/error:*max-traceback-depth*
@@ -24,18 +26,21 @@
   (log4cl-extras/config:setup
     `(:level ,level
       :appenders ((daily :layout :json
-                         :name-format ,(format nil "~A/app.log"
-                                               log-dir)
+                         :name-format ,(format nil "~A/~A.log"
+                                               log-dir
+                                               app)
                          :backup-name-format "app-%Y%m%d.log")))))
 
 
-(defun setup-for-repl (&key (level :debug) (app "app"))
+(defun setup-for-repl (&key
+                         (level :debug)
+                         (app "app"))
   (setf log4cl-extras/error:*max-traceback-depth*
         *max-depth*)
   
   (let ((filename (format nil "~A/~A.log"
                           (or *log-dir*
-                              "/tmp")
+                              "/app/logs")
                           app))
         (backup-filename (format nil "~A-%Y%m%d.log"
                                  app)))

--- a/src/metrics.lisp
+++ b/src/metrics.lisp
@@ -3,25 +3,11 @@
   (:import-from #:ultralisp/stats
                 #:add-counter
                 #:add-gauge)
-  (:import-from #:ultralisp/models/project
-                #:project)
   (:import-from #:mito
                 #:count-dao)
-  (:import-from #:ultralisp/models/version
-                #:version)
-  (:import-from #:weblocks-auth/models
-                #:user)
   (:import-from #:function-cache
                 #:defcached)
-  (:import-from #:ultralisp/models/check
-                #:base-check)
-  (:export
-   #:get-number-of-disabled-projects
-   #:get-number-of-projects
-   #:get-number-of-users
-   #:get-number-of-versions
-   #:get-pending-checks-count
-   #:initialize))
+  (:export #:initialize))
 (in-package ultralisp/metrics)
 
 
@@ -29,32 +15,75 @@
   "To not load a database, we'll not count these metrics every time when Prometheus checks the values.")
 
 
+(defun count-by-sql (query)
+  (let ((rows (mito:retrieve-by-sql query)))
+    (getf (first rows)
+          :count)))
+
+
 (defcached (get-number-of-projects :timeout *ttl*) ()
-  (count-dao 'project :enabled 1))
+  (count-by-sql "SELECT COUNT(*)
+                   FROM project2
+                  WHERE latest = 'true'
+                    AND deleted = 'false'"))
 
 
-(defcached (get-number-of-disabled-projects :timeout *ttl*) ()
-  (count-dao 'project :enabled 0))
+(defcached (get-number-of-sources :timeout *ttl*) ()
+  (count-by-sql "SELECT COUNT(*)
+                   FROM source
+                  WHERE latest = 'true'
+                    AND deleted = 'false'"))
+
+(defcached (get-number-of-disabled-sources :timeout *ttl*) ()
+  (count-by-sql "SELECT COUNT(*)
+                   FROM source
+                   JOIN dist_source
+                     ON source.id = dist_source.source_id
+                  WHERE source.latest = 'true'
+                    AND source.deleted = 'false'
+                    AND dist_source.enabled = 'false'"))
 
 
-(defcached (get-number-of-versions :timeout *ttl*) ()
-  (count-dao 'version))
+(defcached (get-number-of-dists :timeout *ttl*) ()
+  (count-by-sql "SELECT COUNT(*)
+                   FROM dist
+                  WHERE latest = 'true'"))
 
 
 (defcached (get-number-of-users :timeout *ttl*) ()
-  (count-dao 'user))
+  (count-by-sql "SELECT COUNT(*)
+                   FROM \"user\""))
+
+
+(defcached (get-project-index-queue-count :timeout *ttl*) ()
+  (count-by-sql
+   "SELECT COUNT(*)
+      FROM project_index
+     WHERE next_update_at < NOW()"))
+
+
+(defcached (get-project-index-ok-count :timeout *ttl*) ()
+  (count-by-sql
+   "SELECT COUNT(*)
+      FROM project_index
+     WHERE status = 'ok'"))
+
+
+(defcached (get-project-index-failed-count :timeout *ttl*) ()
+  (count-by-sql
+   "SELECT COUNT(*)
+      FROM project_index
+     WHERE status = 'failed'"))
 
 
 ;; Here we use lesser timeout because this value will change more
 ;; frequently
-(defcached (get-pending-checks-count :timeout 60) ()
-  (length (remove-if-not (lambda (check)
-                           (null (ultralisp/models/check:get-processed-at check)))
-                         (mito:retrieve-dao 'base-check)))
-  ;; TODO: return when https://github.com/fukamachi/mito/issues/56 will be fixed
-  ;; (count-dao 'base-check :processed-at :null)
-  )
 
+(defcached (get-pending-checks-count :timeout 60) ()
+  (count-by-sql
+   "SELECT COUNT(*)
+      FROM check2
+     WHERE processed_at IS NULL"))
 
 
 (defun initialize ()
@@ -63,18 +92,25 @@
   (add-counter :checks-processed "A number of processed checks")
   (add-counter :checks-failed "A number of failed checks")
   (add-counter :sources-updated "A number of sources, updated after the check")
-  ;; TODO: remove
-  (add-counter :projects-updated "A number of projects, updated after the check")
-  
+
   (add-gauge :projects-count "A number of projects"
-             'ultralisp/metrics:get-number-of-projects)
-  (add-gauge :disabled-projects-count "A number of disabled projects"
-             'ultralisp/metrics:get-number-of-disabled-projects)
-  (add-gauge :versions-count "A number of Ultralisp versions"
-             'ultralisp/metrics:get-number-of-versions)
+             'get-number-of-projects)
+  (add-gauge :sources-count "A number of sources"
+             'get-number-of-sources)
+  (add-gauge :disabled-sources-count "A number of disabled sources"
+             'get-number-of-disabled-sources)
+  (add-gauge :dists-count "A number of dists"
+             'get-number-of-dists)
   (add-gauge :users-count "A number of users"
-             'ultralisp/metrics:get-number-of-users)
+             'get-number-of-users)
   (add-gauge :pending-checks-count "A number of not processed checks"
-             'ultralisp/metrics:get-pending-checks-count)
+             'get-pending-checks-count)
+  
+  (add-gauge :project-index-queue-count "A number of projects to index"
+             'get-project-index-queue-count)
+  (add-gauge :project-index-ok-count "A number of projects we were successfully indexed"
+             'get-project-index-ok-count)
+  (add-gauge :project-index-failed-count "A number of projects we were unable to index"
+             'get-project-index-failed-count)
   
   (values))

--- a/src/models/project.lisp
+++ b/src/models/project.lisp
@@ -548,8 +548,6 @@
               force)
       (log:info "Updating the project and creating actions" project data force)
 
-      (increment-counter :projects-updated)
-      
       (cond
         ((is-enabled-p project)
          (uiop:symbol-call :ultralisp/models/action

--- a/src/rpc/command.lisp
+++ b/src/rpc/command.lisp
@@ -15,7 +15,7 @@
 (in-package ultralisp/rpc/command)
 
 
-(defparameter *catch-commands* nil)
+(defvar *catch-commands* nil)
 
 
 (serapeum:defvar-unbound *catched*


### PR DESCRIPTION
…use it was each time killed by OOM killer.

Now the indexer will wait for 5 minutes and remove the job
from the Gearman server.

Also, Prometheus metrics were added to show number
of indexed projects and a number of fails.