### PR TITLE
Fixed the way how worker's fatal errors are handled.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,13 @@
  ChangeLog
 ===========
 
+1.9.4 (2021-07-12)
+==================
+
+* Fixed the way how worker's fatal errors are handled.
+  Now if heap or memory was exhausted and worker crashed,
+  it will retry the check 3 times and then mark it as failed.
+
 1.9.3 (2021-06-13)
 ==================
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -9,6 +9,11 @@
   Now if heap or memory was exhausted and worker crashed,
   it will retry the check 3 times and then mark it as failed.
 
+* Switched to the newer dependencies and Quickdist 0.16.4
+  where processing infinite reqursion and stack overflow
+  were fixed for
+  `lispbuilder-opengl-1-2 did <https://github.com/lispbuilder/lispbuilder/blob/b7df0f2f9bd46da5ff322427d4bc6e6eefbfa722/lispbuilder-opengl/lispbuilder-opengl-1-2.asd>`_ system.
+
 1.9.3 (2021-06-13)
 ==================
 

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -14,6 +14,13 @@
   were fixed for
   `lispbuilder-opengl-1-2 did <https://github.com/lispbuilder/lispbuilder/blob/b7df0f2f9bd46da5ff322427d4bc6e6eefbfa722/lispbuilder-opengl/lispbuilder-opengl-1-2.asd>`_ system.
 
+* Fixed ``SELECT-BY-SQL`` calls, to work with latest (and broken Mito).
+  Here is the `pull-request <https://github.com/fukamachi/mito/pull/101>`_ where Mito was fixed.
+  After it will be merged, we can remove ``FIND-CLASS`` calls.
+
+* Now ``WITH-CONNECTION`` macro reuses existing connection for nested calls in cached mode.
+  This fixes tests broken after the Mito and other dependencies upgrade.
+
 1.9.3 (2021-06-13)
 ==================
 

--- a/app-deps.asd
+++ b/app-deps.asd
@@ -133,7 +133,6 @@
   "named-readtables"
   "net.didierverna.clon.core"
   "net.didierverna.clon.setup"
-  "optima"
   "parenscript"
   "parse-declarations-1.0"
   "parse-number"

--- a/qlfile
+++ b/qlfile
@@ -1,6 +1,6 @@
 dist ultralisp http://dist.ultralisp.org/
 
-github quickdist ultralisp/quickdist :tag v0.16.2
+github quickdist ultralisp/quickdist :tag v0.16.4
 
 # Until this issue will be resolved:
 # https://github.com/ultralisp/ultralisp/issues/73

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,23 +1,23 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2021-05-31"))
+  :version "2021-06-30"))
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org/" :%version :latest)
-  :version "20210603160500"))
+  :version "20210713023500"))
 ("quickdist" .
  (:class qlot/source/github:source-github
-  :initargs (:repos "ultralisp/quickdist" :ref nil :branch nil :tag "v0.16.2")
-  :version "github-d2a61646eeb90d472b316cf4fae61359"))
+  :initargs (:repos "ultralisp/quickdist" :ref nil :branch nil :tag "v0.16.4")
+  :version "github-ae261541bf70fb3f1ae4dc4160dca96e"))
 ("cl-str" .
  (:class qlot/source/ql:source-ql
   :initargs (:%version :latest)
-  :version "ql-2021-05-31"))
+  :version "ql-2021-06-30"))
 ("ironclad" .
  (:class qlot/source/ql:source-ql
   :initargs (:%version :latest)
-  :version "ql-2021-05-31"))
+  :version "ql-2021-06-30"))
 ("slynk-named-readtables" .
  (:class qlot/source/github:source-github
   :initargs (:repos "joaotavora/sly-named-readtables" :ref nil :branch nil :tag nil)

--- a/src/models/check.lisp
+++ b/src/models/check.lisp
@@ -56,7 +56,6 @@
    #:get-check-by-id
    #:any-check
    #:get-processed-in
-   #:get-last-project-check
    #:get-pending-checks-count
    #:get-pending-checks-for-disabled-projects
    #:get-pending-checks-for-disabled-projects-count

--- a/src/models/dist-moderator.lisp
+++ b/src/models/dist-moderator.lisp
@@ -40,7 +40,7 @@
    to not overhelm them."
   (check-type user weblocks-auth/models:user)
   (mito.dao:select-by-sql
-   'dist
+   (find-class 'dist)
    "SELECT dist.* FROM dist
       JOIN dist_moderator ON dist.id = dist_moderator.dist_id
      WHERE dist_moderator.user_id = ?

--- a/src/models/dist-source.lisp
+++ b/src/models/dist-source.lisp
@@ -166,7 +166,7 @@ SELECT *
                            (if enabled
                                "   AND enabled = true"
                                "   AND enabled = false"))))
-      (mito.dao:select-by-sql 'dist-source
+      (mito.dao:select-by-sql (find-class 'dist-source)
                               sql
                               :binds params)))
   
@@ -206,7 +206,7 @@ SELECT *
                    " LIMIT ?"))
         (setf params (append params
                              (list limit))))
-      (mito.dao:select-by-sql 'dist-source
+      (mito.dao:select-by-sql (find-class 'dist-source)
                               sql
                               :binds params))))
 

--- a/src/models/index.lisp
+++ b/src/models/index.lisp
@@ -151,7 +151,7 @@
 
 (defun get-projects-to-index (&key (limit 10))
   "Returns a list of projects to update a search index."
-  (mito.dao:select-by-sql 'project2
+  (mito.dao:select-by-sql (find-class 'project2)
                           "
 WITH projects_with_sources AS (
   SELECT distinct source.project_id

--- a/src/models/project-moderator.lisp
+++ b/src/models/project-moderator.lisp
@@ -48,7 +48,7 @@
    to not overhelm them."
   (check-type user user)
   (mito.dao:select-by-sql
-   'project2
+   (find-class 'project2)
    "SELECT project2.* FROM project2
       JOIN project_moderator ON project2.id = project_moderator.project_id
      WHERE project_moderator.user_id = ?
@@ -80,7 +80,7 @@
 
 (defmethod moderators ((project project2))
   (mito.dao:select-by-sql
-   'user
+   (find-class 'user)
    "SELECT \"user\".* FROM \"user\"
       JOIN project_moderator ON \"user\".id = project_moderator.user_id
      WHERE project_moderator.project_id = ?

--- a/src/models/project.lisp
+++ b/src/models/project.lisp
@@ -358,7 +358,7 @@
 
 (defun get-projects-with-sources ()
   "Returns projects with not deleted sources."
-  (mito.dao:select-by-sql 'project2
+  (mito.dao:select-by-sql (find-class 'project2)
                           "
     WITH projects_with_sources AS (
       SELECT distinct source.project_id

--- a/src/utils/retries.lisp
+++ b/src/utils/retries.lisp
@@ -1,0 +1,87 @@
+(defpackage #:ultralisp/utils/retries
+  (:use #:cl)
+  (:import-from #:alexandria
+                #:with-output-to-file)
+  (:import-from #:ultralisp/utils
+                #:delete-file-if-exists)
+  (:documentation "This package contains a code to track complete
+                   failures when worker process dies because of some reason.
+
+                   The idea is to append timestamps into a files where
+                   filename contains a check's id. And if there already was N attempts
+                   in M minutes, then on it's next call WITH-TRIES macro will log message and
+                   signal an error.")
+  (:export
+   #:with-tries))
+(in-package ultralisp/utils/retries)
+
+
+(defparameter *data-dir* #P"/tmp/retries/")
+
+
+(defun read-timestamps (check-id)
+  (let ((filename (merge-pathnames (princ-to-string check-id)
+                                   *data-dir*)))
+    (cond
+      ((probe-file filename)
+       (uiop:read-file-form filename))
+      (t
+       nil))))
+
+
+(defun save-timestamps (check-id timestamps)
+  (let ((filename (merge-pathnames (princ-to-string check-id)
+                                   *data-dir*)))
+    (ensure-directories-exist filename)
+
+    (with-output-to-file (s filename
+                            :if-exists :supersede)
+      (write timestamps
+             :stream s))
+    (values)))
+
+
+(defun clear-timestamps (check-id)
+  (let ((filename (merge-pathnames (princ-to-string check-id)
+                                   *data-dir*)))
+    (delete-file-if-exists filename)
+    (values)))
+
+
+(defun filter-timestamps (timestamps window)
+  (loop with time-in-past = (- (get-universal-time) window)
+        for ts in timestamps
+        when (> ts time-in-past)
+        collect ts))
+
+
+(defun call-with-tries (check-id num-attempts time-window func)
+  (let* ((all-timestamps (read-timestamps check-id))
+         (timestamps (filter-timestamps all-timestamps time-window)))
+
+    (cond
+      ((>= (length timestamps)
+           num-attempts)
+       (error "We've made ~A attempts in ~A seconds for check-id = ~A"
+              (length timestamps)
+              time-window
+              check-id))
+      (t
+       (push (get-universal-time)
+             timestamps)
+       (save-timestamps check-id timestamps)
+
+       (multiple-value-prog1
+           (funcall func)
+         (clear-timestamps check-id))))))
+
+
+(defmacro with-tries ((check-id &key (num-attempts 3)
+                                     (time-window (* 5 60)))
+                      &body body)
+  "Raises an error if body was executed NUM-ATTEMPTS times in TIME-WINDOW seconds,
+   but Lisp crashed and didn't finished execution."
+  `(call-with-tries ,check-id ,num-attempts ,time-window
+                    (lambda ()
+                      ,@body)))
+


### PR DESCRIPTION
Now if heap or memory was exhausted and worker crashed,
it will retry the check 3 times and then mark it as failed.