### PR TITLE
Macro WITH-CONNECTION now signals error if we attempt to get cached connection when non-cached one is active.

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,14 @@
  ChangeLog
 ===========
 
+1.16.10 (2022-09-24)
+====================
+
+* Macro WITH-CONNECTION now signals error if we attempt to get cached connection when non-cached one is active.
+
+  This should prevent errors where cl-dbi tries to commit or rollback connection which already closed:
+  "DB Error: Connection to database server lost".
+
 1.16.9 (2022-09-24)
 ===================
 

--- a/docker/s6-app/app1/run
+++ b/docker/s6-app/app1/run
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+DATE=$(date --rfc-3339=seconds)
+
+function print_banner () {
+  cat >> $1 <<EOF
+     =======================
+ ===============================
+=== Process started at:       ===
+=== ${DATE} ===
+ ===============================
+     =======================
+EOF
+}
+
+print_banner /app/logs/app-stdout.log
+print_banner /app/logs/app-stderr.log
+
 /app/ultralisp-server \
 	>> /app/logs/app-stdout.log \
 	2>> /app/logs/app-stderr.log

--- a/docker/s6-app/app1/run
+++ b/docker/s6-app/app1/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 /app/ultralisp-server \
-	> /app/logs/app-stdout.log \
-	2> /app/logs/app-stderr.log
+	>> /app/logs/app-stdout.log \
+	2>> /app/logs/app-stderr.log
 

--- a/docker/s6-lw-worker/worker1/run
+++ b/docker/s6-lw-worker/worker1/run
@@ -1,5 +1,22 @@
 #!/bin/bash
 
+DATE=$(date --rfc-3339=seconds)
+
+function print_banner () {
+  cat >> $1 <<EOF
+     =======================
+ ===============================
+=== Process started at:       ===
+=== ${DATE} ===
+ ===============================
+     =======================
+EOF
+}
+
+print_banner /app/logs/lw-worker-stdout.log
+print_banner /app/logs/lw-worker-stderr.log
+
+
 if [[ ! -e /usr/local/lib64/LispWorks/lib/8-0-0-0/config/lwlicense ]] || ! grep -q $(hostname) /usr/local/lib64/LispWorks/lib/8-0-0-0/config/lwlicense; then
     if [[ -e /lw/license ]]; then
         /usr/local/lib64/LispWorks/lispworks-8-0-0-amd64-linux $(cat /lw/license)

--- a/docker/s6-lw-worker/worker1/run
+++ b/docker/s6-lw-worker/worker1/run
@@ -11,5 +11,5 @@ fi
         --slynk-interface "0.0.0.0" \
         --slynk-port "4005" \
         --debug \
-        > /app/logs/lw-worker-stdout.log \
-        2> /app/logs/lw-worker-stderr.log
+        >> /app/logs/lw-worker-stdout.log \
+        2>> /app/logs/lw-worker-stderr.log

--- a/docker/s6-worker/worker1/run
+++ b/docker/s6-worker/worker1/run
@@ -4,5 +4,5 @@
         --slynk-interface "0.0.0.0" \
         --slynk-port "4005" \
         --debug \
-        > /app/logs/worker-stdout.log \
-        2> /app/logs/worker-stderr.log
+        >> /app/logs/worker-stdout.log \
+        2>> /app/logs/worker-stderr.log

--- a/docker/s6-worker/worker1/run
+++ b/docker/s6-worker/worker1/run
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+DATE=$(date --rfc-3339=seconds)
+
+function print_banner () {
+  cat >> $1 <<EOF
+     =======================
+ ===============================
+=== Process started at:       ===
+=== ${DATE} ===
+ ===============================
+     =======================
+EOF
+}
+
+print_banner /app/logs/worker-stdout.log
+print_banner /app/logs/worker-stderr.log
+
 /app/worker \
         --slynk-interface "0.0.0.0" \
         --slynk-port "4005" \


### PR DESCRIPTION
This should prevent errors where cl-dbi tries to commit or rollback connection which already closed:
"DB Error: Connection to database server lost".