### PR TITLE
Added 15 minutes timeout on each RPC command

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,16 @@
  ChangeLog
 ===========
 
+1.16.13 (2022-10-16)
+====================
+
+* Added 15 minutes timeout on each RPC command.
+* Extra logging of archive uploading errors.
+
+  I suspect that sometimes S3 responds with:
+  ``ZS3:SLOW-DOWN: SlowDown: Please reduce your request rate.``
+  error and projects check hangs.
+
 1.16.12 (2022-09-25)
 ====================
 

--- a/src/github/webhook.lisp
+++ b/src/github/webhook.lisp
@@ -89,19 +89,23 @@
 (defun find-project-related-to (payload)
   "Searches a projects metadata among all projects, known to Ultralisp.
    Returns a `project' object or nil."
+  ;; TODO: probably this code should be fixed to
+  ;; use branch name from the project's source definition
   (let ((current-branch (get-branch-from payload))
-        (main-branch (get-main-branch-from payload)))
+        (main-branch (get-main-branch-from payload))
+        (project-name (fmt "~A/~A"
+                           (get-user-or-org-from payload)
+                           (get-project-name-from payload))))
     (cond
       ((and current-branch
             (string-equal current-branch
                           main-branch))
 
-       (let* ((user-or-org (get-user-or-org-from payload))
-              (project-name (get-project-name-from payload)))
-         (get-project2 (fmt "~A/~A" user-or-org project-name))))
+       (get-project2 project-name))
       
       (t (if current-branch
              (log:warn "Current branch does not match to main"
+                       project-name
                        current-branch
                        main-branch)
              (log:warn "Unable to figure out current branch from the payload"))

--- a/src/uploader/base.lisp
+++ b/src/uploader/base.lisp
@@ -4,6 +4,7 @@
                 #:starts-with-slash-p
                 #:ends-with-slash-p)
   (:import-from #:trivial-timeout)
+  (:import-from #:log4cl-extras/error)
   (:import-from #:str)
   (:export
    #:make-uploader
@@ -48,10 +49,11 @@
   (unless (member repo-type '(:quicklisp :clpi))
     (error "REPO-TYPE argument should be one of :QUICKLISP or :CLPI"))
   (trivial-timeout:with-timeout (timeout)
-    (funcall (make-uploader *uploader-type* repo-type)
-             dir-or-file
-             destination
-             :only-files only-files)))
+    (log4cl-extras/error:with-log-unhandled ()
+      (funcall (make-uploader *uploader-type* repo-type)
+               dir-or-file
+               destination
+               :only-files only-files))))
 
 
 (defun make-files-inclusion-checker (only-files)


### PR DESCRIPTION
Extra logging of archive uploading errors.

I suspect that sometimes S3 responds with:
`ZS3:SLOW-DOWN: SlowDown: Please reduce your request rate.`
error and projects check hangs.