### PR TITLE
Remove dexador thread safety bug fix

### DIFF
--- a/src/server.lisp
+++ b/src/server.lisp
@@ -420,17 +420,6 @@
   (setf lparallel:*kernel* (make-kernel 8
                                         :name "parallel worker"))
 
-  ;; This fixes issue with Dexador's thread-safety:
-  ;; https://github.com/fukamachi/dexador/issues/88
-  (setf (dbi.cache.thread::cache-pool-hash cl-dbi::*threads-connection-pool*)
-        (make-hash-table :test 'equal :synchronized t))
-
-  ;; We need this becase Dexador's thread pool is
-  ;; not threadsafe yet. You'll find more details in this issue:
-  ;; https://github.com/fukamachi/dexador/issues/88
-  (setf dexador.connection-cache::*threads-connection-pool*
-        (make-hash-table :test 'equal :synchronized t))
-
   (setf mailgun:*domain* (get-mailgun-domain))
   (unless mailgun:*domain*
     (log:error "Set MAILGUN_DOMAIN environment variable, otherwise login will not work"))


### PR DESCRIPTION
Global variable `*threads-connection-pool*` has been removed from `dexador`.