### PR TITLE
Don't create a check with NIL lisp implementaion

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,7 +2,21 @@
  ChangeLog
 ===========
 
+1.24.3 (2023-12-10)
+===================
+
+* Fixed a rare error when source check was created with "nil" string in lisp_implementation slot.
+
+  Presumable, the problem occur when a check is created for the source not bound to any quicklisp distribution.
+
+  Previously a check was created with "nil" in the lisp_implementation slot. Because of that, no worker was able to process such a check.
+
+  Also, such check prevented creation of new correct checks because "check already exists" error.
+
+  After the fix check will not be created in this case.
+
 1.24.2 (2023-10-22)
+===================
 
 * Use deploy token to autotrigger builds.
 

--- a/DEV.org
+++ b/DEV.org
@@ -48,8 +48,9 @@ Eval ~(ultralisp/worker:process-jobs)~ there:
 (ultralisp/db:connect-toplevel)
 
 (ultralisp/rpc/core:submit-task 'ultralisp/pipeline/checking:perform
-                                (ultralisp/models/check:make-via-cron-check
-                                 (ultralisp/models/project:get-github-project "guicho271828" "type-i"))
+                                (ultralisp/models/check:make-checks
+                                 (ultralisp/models/project:get-github-project "guicho271828" "type-i")
+                                 :manual)
                                 :force t)
 #+END_SRC
 

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,11 +1,11 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2023-09-06"))
+  :version "2023-10-21"))
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org/" :%version :latest)
-  :version "20231021230536"))
+  :version "20231209220501"))
 ("quickdist" .
  (:class qlot/source/github:source-github
   :initargs (:repos "ultralisp/quickdist" :ref "3cd3bdbb2d681157c41bd0584e6a2bbfcc60049f" :branch nil :tag nil)

--- a/src/debug.lisp
+++ b/src/debug.lisp
@@ -1,15 +1,15 @@
-(defpackage #:ultralisp/debug
+(uiop:define-package #:ultralisp/debug
   (:use #:cl)
   (:import-from #:ultralisp/models/project
+                #:project-sources
                 #:get-github-project)
   (:import-from #:ultralisp/models/check
-                #:make-via-cron-check)
+                #:make-checks)
   (:import-from #:ultralisp/db
                 #:with-transaction)
   (:import-from #:ultralisp/pipeline/checking
                 #:perform-pending-checks)
-  (:export
-   #:check-project))
+  (:export #:check-project))
 (in-package #:ultralisp/debug)
 
 ;; To make development more predictable, stop the cronjobs before going further:
@@ -23,7 +23,7 @@
 (defun check-project (username project-name)
   "Creates a check and performs it like ultralisp usually do."
   (let* ((project (get-github-project username project-name)))
-    (make-via-cron-check project)
+    (make-checks project :via-cron)
     (with-transaction
       (perform-pending-checks :force t))
     ;; return an updated object from DB

--- a/src/github/webhook.lisp
+++ b/src/github/webhook.lisp
@@ -28,8 +28,7 @@
   (:import-from #:reblocks/response
                 #:make-uri)
   (:import-from #:ultralisp/models/check
-                #:make-checks
-                #:make-via-webhook-check)
+                #:make-checks)
   (:import-from #:log4cl-extras/error
                 #:with-log-unhandled)
   (:import-from #:ultralisp/db

--- a/src/widgets/project.lisp
+++ b/src/widgets/project.lisp
@@ -116,15 +116,6 @@
                                 :editable t))))))
 
 
-(defun toggle (widget project)
-  (check-type widget project)
-  (check-type project ultralisp/models/project:project)
-  (if (is-enabled-p project)
-      (disable-project project :reason :manual)
-      (ultralisp/models/check:make-added-project-check project))
-  (reblocks/widget:update widget))
-
-
 (defclass next-check ()
   ((at :initarg :at
        :reader get-time)))


### PR DESCRIPTION
Presumable, the problem occur when a check is created for the source not bound to any quicklisp distribution.

Previously a check was created with "nil" in the lisp_implementation slot. Because of that, no worker was able to process such a check.

Also, such check prevented creation of new correct checks because "check already exists" error.

After the fix check will not be created in this case.

This PR should fix issue https://github.com/ultralisp/ultralisp/issues/241