### PR TITLE
Normalize license info when collecting system info.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@
       "env": {
         "OS": "ubuntu-latest",
         "QUICKLISP_DIST": "quicklisp",
-        "LISP": "sbcl-bin/2.2.5"
+        "LISP": "sbcl-bin/2.4.6"
       },
       "steps": [
         {
@@ -82,7 +82,7 @@
       "env": {
         "OS": "ubuntu-latest",
         "QUICKLISP_DIST": "quicklisp",
-        "LISP": "sbcl-bin/2.1.2"
+        "LISP": "sbcl-bin/2.4.6"
       },
       "steps": [
         {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,6 @@
           "name": "Setup Common Lisp Environment",
           "uses": "40ants/setup-lisp@v4",
           "with": {
-            "qlot-no-deps": "true",
             "asdf-system": "ultralisp-docs",
             "cache": "true"
           }

--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,14 @@
  ChangeLog
 ===========
 
+1.26.6 (2025-02-14)
+===================
+
+* Normalize license info when collecting system info.
+  Some authors may use symbol as license name like in:
+  https://github.com/ajberkley/cl-binary-store/blob/3b0587eaaa74c79734477cb38132237411068ef8/cl-binary-store.asd#L66
+  But we need to serialize it to JSON. Yason library fails to serialize symbols, so we cast license to string now.
+
 1.26.5 (2024-11-30)
 ===================
 

--- a/qlfile
+++ b/qlfile
@@ -33,7 +33,7 @@ github cl-gearman svetlyak40wt/cl-gearman :branch patches
 
 # Waiting for this PR to be merged:
 # https://github.com/fukamachi/cl-dbi/pull/87
-github cl-dbi svetlyak40wt/cl-dbi :branch application-name
+# github cl-dbi svetlyak40wt/cl-dbi :branch application-name
 
 # Until this PR will be merged:
 # https://github.com/Shinmera/legit/pull/11
@@ -43,3 +43,8 @@ github cl-dbi svetlyak40wt/cl-dbi :branch application-name
 # Until this PR will be merged:
 # https://github.com/thephoeron/cl-isaac/pull/13
 github cl-isaac svetlyak40wt/cl-isaac :branch fix-value-1-error
+
+
+# Until we solve https://github.com/fukamachi/qlot/issues/265
+# and https://github.com/ultralisp/ultralisp/issues/278
+# github qlot fukamachi/qlot :ref a4abc8921c4a8cf1c43f453bb2106ee56ae3c13d

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,11 +1,11 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
-  :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2023-10-21"))
+  :initargs (:distribution "https://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
+  :version "2024-10-12"))
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
-  :initargs (:distribution "http://dist.ultralisp.org/" :%version :latest)
-  :version "20240707082001"))
+  :initargs (:distribution "https://dist.ultralisp.org/" :%version :latest)
+  :version "20250214205000"))
 ("quickdist" .
  (:class qlot/source/github:source-github
   :initargs (:repos "ultralisp/quickdist" :ref "9d6b0ef58d84ad1204b9ad209f51d93e1150f2ca" :branch nil :tag nil)
@@ -18,10 +18,6 @@
  (:class qlot/source/github:source-github
   :initargs (:repos "svetlyak40wt/cl-gearman" :ref nil :branch "patches" :tag nil)
   :version "github-a4d2ebbd1b05670ac712b8ac623bf6b916fa526e"))
-("cl-dbi" .
- (:class qlot/source/github:source-github
-  :initargs (:repos "svetlyak40wt/cl-dbi" :ref nil :branch "application-name" :tag nil)
-  :version "github-f2f507892ecbc38df262f6f8a945abe7726e3dad"))
 ("cl-isaac" .
  (:class qlot/source/github:source-github
   :initargs (:repos "svetlyak40wt/cl-isaac" :ref nil :branch "fix-value-1-error" :tag nil)

--- a/src/ci.lisp
+++ b/src/ci.lisp
@@ -51,9 +51,9 @@
   :cache t
   :env (("CL_SOURCE_REGISTRY" . "${{ github.workspace }}/"))
   :jobs ((linter
-          :lisp "sbcl-bin/2.2.5")
+          :lisp "sbcl-bin/2.4.6")
          (run-tests
-          :lisp "sbcl-bin/2.1.2"
+          :lisp "sbcl-bin/2.4.6"
           ;; Does not work because cl-coverage complains
           ;; it can't quickload app-deps. Hmmm...
           ;; :coverage nil
@@ -64,7 +64,7 @@
   :on-push-to "master"
   :by-cron "0 10 * * 1"
   :on-pull-request t
-  ;; :cache t
+  :cache t
   :jobs ((build-docs :asdf-system "ultralisp-docs"
                      ;; Because of unknown issue, builder on CI shows this message but not a single warning:
                      ;; WARNING: 92 warnings were caught

--- a/src/models/check.lisp
+++ b/src/models/check.lisp
@@ -218,7 +218,9 @@
                               :lisp-implementation implementation)
              t))
            (t
-            (log:error "Unable to make a check for project because it has no sources bound to some implementation")
+            ;; There are many such projects in the production.
+            ;; Don't know what to do with them :(
+            (log:info "Unable to make a check for project because it has no sources bound to some implementation")
             (values nil nil)))))))
 
 

--- a/src/models/utils.lisp
+++ b/src/models/utils.lisp
@@ -39,6 +39,15 @@
     (t nil)))
 
 
+(defun %normalize-license (license)
+  (typecase license
+    (string license)
+    (t
+     (log:warn "Project's license is not string: ~S. Coercing to string."
+               license)
+     (princ-to-string license))))
+
+
 (defun %system-info-to-json (system-info)
   (check-type system-info system-info)
 
@@ -49,7 +58,11 @@
         "FILENAME" (get-filename system-info)
         "NAME" (quickdist:get-name system-info)
         "DEPENDENCIES" (get-dependencies system-info)
-        "LICENSE" (ultralisp/models/system-info::system-info-license system-info)
+        ;; Some authors may use symbol as license name like in:
+        ;; https://github.com/ajberkley/cl-binary-store/blob/3b0587eaaa74c79734477cb38132237411068ef8/cl-binary-store.asd#L66
+        ;; But we need to serialize it to JSON:
+        "LICENSE" (%normalize-license
+                   (ultralisp/models/system-info::system-info-license system-info))
         "AUTHOR" (%normalize-names
                   (ultralisp/models/system-info::system-info-author system-info))
         "MAINTAINER" (%normalize-names


### PR DESCRIPTION
Some authors may use symbol as license name like in: https://github.com/ajberkley/cl-binary-store/blob/3b0587eaaa74c79734477cb38132237411068ef8/cl-binary-store.asd#L66 But we need to serialize it to JSON. Yason library fails to serialize symbols, so we cast license to string now.