### PR TITLE
Two fixes

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,12 @@
  ChangeLog
 ===========
 
+1.26.8 (2025-02-15)
+===================
+
+* Fixed the way how "processed" dist version are processed. Now each dist is processed in a separate transaction. Also, we collect garbage between dist builds.
+* Fixed a login page broken after the last dependencies upgrade.
+
 1.26.7 (2025-02-15)
 ===================
 

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -5,7 +5,7 @@
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "https://dist.ultralisp.org/" :%version :latest)
-  :version "20250214205000"))
+  :version "20250215102501"))
 ("quickdist" .
  (:class qlot/source/github:source-github
   :initargs (:repos "ultralisp/quickdist" :ref "9d6b0ef58d84ad1204b9ad209f51d93e1150f2ca" :branch nil :tag nil)

--- a/src/db.lisp
+++ b/src/db.lisp
@@ -15,6 +15,7 @@
                 #:make-hmac
                 #:ascii-string-to-byte-array)
   (:import-from #:ultralisp/variables
+                #:*in-unit-test*
                 #:get-postgres-pass
                 #:get-postgres-user
                 #:get-postgres-host
@@ -166,7 +167,11 @@
     (error 'connection-error
            :message "Unable to get cached connection inside a block with non-cached connection."))
 
-  (let* ((*was-cached* cached)
+  (let* ((cached (or cached
+                     ;; In unit tests we have to use the same connection,
+                     ;; because database schema exists only inside transaction:
+                     *in-unit-test*))
+         (*was-cached* cached)
          (mito:*connection*
            ;; In cached mode we will reuse current connect.
            ;; This way, nested WITH-CONNECTION calls will

--- a/src/pipeline/checking.lisp
+++ b/src/pipeline/checking.lisp
@@ -264,10 +264,7 @@
     ;; check really be marked as failed even if there are some
     ;; other commands which will cause rollback of the outer
     ;; postgres connection:
-    (with-connection (:cached
-                      ;; In unit tests we have to use the same connection,
-                      ;; because database schema exists only inside transaction:
-                      *in-unit-test*)
+    (with-connection (:cached nil)
       (with-transaction
         (let ((project (check->project check)))
           (with-fields (:project-name (project-name project))

--- a/src/utils/timing.lisp
+++ b/src/utils/timing.lisp
@@ -1,0 +1,32 @@
+(uiop:define-package #:ultralisp/utils/timing
+  (:use #:cl)
+  (:import-from #:alexandria
+                #:with-gensyms))
+(in-package #:ultralisp/utils/timing)
+
+
+(defvar *timings* (make-hash-table))
+
+
+(defun report-timings ()
+  (loop for key being the hash-key of *timings*
+        using (hash-value values)
+        for summ = (reduce #'+ values :initial-value 0)
+        for metrics-count = (length values)
+        for avg = (/ summ metrics-count)
+        collect (list key avg summ metrics-count)))
+
+
+(defmacro with-timings ((name) &body body)
+  (with-gensyms (started-at stopped-at timing)
+    `(let ((,started-at (get-internal-real-time)))
+       (multiple-value-prog1 (progn ,@body)
+         (let* ((,stopped-at (get-internal-real-time))
+                (,timing (coerce (/ (- ,stopped-at
+                                        ,started-at)
+                                    internal-time-units-per-second)
+                                 'float)))
+           (push ,timing
+                 (gethash ,name *timings*)))))))
+
+

--- a/src/utils/trace.lisp
+++ b/src/utils/trace.lisp
@@ -1,0 +1,15 @@
+(uiop:define-package #:ultralisp/utils/trace
+  (:use #:cl)
+  (:import-from #:trivial-backtrace
+                #:print-backtrace-to-stream))
+(in-package #:ultralisp/utils/trace)
+
+
+(defun dump-traces (&key (stream *standard-output*))
+  (flet ((dump-trace-and-continue ()
+           (format stream "Thread: ~S~2%"
+                   (bt2:thread-name (bt2:current-thread)))
+           (print-backtrace-to-stream stream)
+           (format stream "~3%")))
+    (loop for thread in (reverse (bt2:all-threads))
+          do (bt2:interrupt-thread thread #'dump-trace-and-continue))))


### PR DESCRIPTION
* Fixed the way how "processed" dist version are processed. Now each dist is processed in a separate transaction. Also, we collect garbage between dist builds.
* Fixed a login page broken after the last dependencies upgrade.