### PR TITLE
Removed dependency of ultralisp/worker from cl-container and metatilities

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,14 @@
  ChangeLog
 ===========
 
+1.27.4 (2025-06-14)
+===================
+
+* Removed dependency of ultralisp/worker from cl-container and metatilities
+
+  These two dependencies caused package variance errors during the project checks.
+
+
 1.27.3 (2025-06-14)
 ===================
 

--- a/roswell/worker.ros
+++ b/roswell/worker.ros
@@ -7,6 +7,12 @@ exec ros dynamic-space-size=4000 -Q -- $0 "$@"
                    (safety 3)
                    (speed 1)))
 
+;; We don't need our worker depend on Reblocks
+;; because it brings N dependencies
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (pushnew :ultralisp-worker-mode *features*))
+
+
 (progn ;;init forms
   (ros:ensure-asdf)
   #+quicklisp(ql:quickload '(;; bordeaux-threads

--- a/src/db.lisp
+++ b/src/db.lisp
@@ -20,6 +20,7 @@
                 #:get-postgres-user
                 #:get-postgres-host
                 #:get-postgres-dbname)
+  #-ultralisp-worker-mode
   (:import-from #:reblocks/response
                 #:immediate-response)
   (:import-from #:secret-values
@@ -136,6 +137,9 @@
 
 (defun call-with-transaction (func)
   (cl-dbi:with-transaction mito:*connection*
+    #+ultralisp-worker-mode
+    (funcall func)
+    #-ultralisp-worker-mode
     (handler-bind ((immediate-response
                      (lambda (condition)
                        (declare (ignorable condition))

--- a/src/models/project.lisp
+++ b/src/models/project.lisp
@@ -32,7 +32,11 @@
                 #:order-by
                 #:limit
                 #:where)
+  #-ultralisp-worker-mode
   (:import-from #:reblocks-auth/models
+                #:get-current-user)
+  #+ultralisp-worker-mode
+  (:import-from #:ultralisp/worker-mocks
                 #:get-current-user)
   (:import-from #:ultralisp/db
                 #:with-transaction)
@@ -57,8 +61,6 @@
                 #:get-project-name)
   (:import-from #:ultralisp/rpc/command
                 #:defcommand)
-  (:import-from #:ultralisp/stats
-                #:increment-counter)
   (:import-from #:ultralisp/models/utils
                 #:systems-info-to-json
                 #:release-info-to-json

--- a/src/models/source.lisp
+++ b/src/models/source.lisp
@@ -15,7 +15,11 @@
                 #:release-info-to-json
                 #:systems-info-from-json
                 #:release-info-from-json)
+  #-ultralisp-worker-mode
   (:import-from #:ultralisp/stats
+                #:increment-counter)
+  #+ultralisp-worker-mode
+  (:import-from #:ultralisp/worker-mocks
                 #:increment-counter)
   (:import-from #:alexandria
                 #:make-keyword)

--- a/src/pipeline/checking.lisp
+++ b/src/pipeline/checking.lisp
@@ -68,7 +68,11 @@
                 #:with-log-unhandled)
   (:import-from #:log4cl-extras/context
                 #:with-fields)
+  #-ultralisp-worker-mode
   (:import-from #:ultralisp/stats
+                #:increment-counter)
+  #+ultralisp-worker-mode
+  (:import-from #:ultralisp/worker-mocks
                 #:increment-counter)
   (:import-from #:ultralisp/models/versioned
                 #:prev-version

--- a/src/uploader/fake.lisp
+++ b/src/uploader/fake.lisp
@@ -7,21 +7,21 @@
   (:import-from #:ultralisp/variables
                 #:get-dist-dir
                 #:get-clpi-dist-dir)
-  (:import-from #:metatilities
-                #:relative-pathname)
   (:import-from #:log)
   (:import-from #:ultralisp/utils
-                #:walk-dir))
+                #:walk-dir
+                #:relative-path))
 (in-package #:ultralisp/uploader/fake)
 
 
 (defmethod make-uploader ((type (eql :fake)) repo-type)
   (lambda (dir-or-file destination-path &key only-files)
-    (let* ((destination-path (relative-pathname (uiop:ensure-directory-pathname
-                                                 (ecase repo-type
-                                                   (:quicklisp (get-dist-dir))
-                                                   (:clpi (get-clpi-dist-dir))))
-                                                destination-path))
+    (let* ((destination-path (relative-path
+                              (uiop:ensure-directory-pathname
+                               (ecase repo-type
+                                 (:quicklisp (get-dist-dir))
+                                 (:clpi (get-clpi-dist-dir))))
+                              destination-path))
            (need-to-upload-p
              (make-files-inclusion-checker only-files)))
       (walk-dir (dir-or-file absolute relative)

--- a/src/worker-mocks.lisp
+++ b/src/worker-mocks.lisp
@@ -1,0 +1,13 @@
+(uiop:define-package #:ultralisp/worker-mocks
+  (:use #:cl))
+(in-package #:ultralisp/worker-mocks)
+
+
+(defun get-current-user ()
+  (error "GET-CURRENT-USER is not available in ultralisp worker mode"))
+
+
+(defun increment-counter (counter-name)
+  (declare (ignore counter-name))
+  (error "INCREMENT-COUNTER function is unavailable in Ultralisp Worker."))
+


### PR DESCRIPTION
These two dependencies caused package variance errors during the project checks.