### PR TITLE
Correction for the GitHub URLs

### DIFF
--- a/src/server.lisp
+++ b/src/server.lisp
@@ -402,7 +402,7 @@
             ((reblocks/debug:status)
              (with-html-string ()
                (:h3 "Some shit happened.")
-               (:h4 ("Don't panic. [Fill issue at GitHub](github.com/ultralisp/ultralisp/issues) and ask to fix it!"))
+               (:h4 ("Don't panic. [Fill issue at GitHub](https://github.com/ultralisp/ultralisp/issues) and ask to fix it!"))
                (when *request-id*
                  (:h4 ("Mention ~S request id in the issue." *request-id*)))
                (when condition
@@ -412,7 +412,7 @@
             (t
              (with-html-string ()
                (:h3 "Some shit happened.")
-               (:h4 ("Don't panic. [Fill issue at GitHub](github.com/ultralisp/ultralisp/issues) and ask to fix it!"))
+               (:h4 ("Don't panic. [Fill issue at GitHub](https://github.com/ultralisp/ultralisp/issues) and ask to fix it!"))
                (when *request-id*
                  (:h4 ("Mention ~S request id in the issue." *request-id*))))))))
     


### PR DESCRIPTION
Related to #314, point 2.

The extra `ultralisp.org` comes from the browser resolving a relative link: in src/server.lisp:405 and src/server.lisp:415 the Markdown string renders to <a
href="github.com/ultralisp/ultralisp/issues">…</a>, so without a scheme it's treated as relative to the current site, giving https://ultralisp.org/github.com/ instead of https://github.com/