### PR TITLE
CI run fix

### DIFF
--- a/t/utils.lisp
+++ b/t/utils.lisp
@@ -55,7 +55,7 @@
 
 (defmacro with-login ((&key (email "bob@example.com"))
                       &body body)
-  `(reblocks-tests/utils:with-session
+  `(reblocks-tests/utils:with-test-session ()
      (let* ((user (or (reblocks-auth/models:get-user-by-email ,email)
                       (mito:create-dao 'reblocks-auth/models:user
                                        :nickname ,email


### PR DESCRIPTION
CI run for tests chokes with
```
caught ERROR:
  READ error during COMPILE-FILE:

    Symbol "WITH-SESSION" not found in the REBLOCKS-TESTS/UTILS package.

      Line: 58, Column: 37, File-Position: 2035

      Stream: #<SB-INT:FORM-TRACKING-STREAM for "file /home/runner/work/ultralisp/ultralisp/t/utils.lisp"
```
There is no `with-session` in `reblocks-tests/utils`, but there is `with-test-session`.