### PR TITLE
Fix/make badges adjustable

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,11 @@
  ChangeLog
 ===========
 
+1.28.2 (2025-09-28)
+====================
+
+* Fixed the SVG badge rendering, so that they are no longer squished
+
 1.28.1 (2025-09-28)
 ====================
 

--- a/src/badges.lisp
+++ b/src/badges.lisp
@@ -22,18 +22,77 @@
        version))
     (t (princ-to-string version))))
 
+(defparameter +badge-side-padding+ 7)
+(defparameter +badge-min-section-width+ 32)
+
+(defun badge-char-width (char)
+  (cond
+    ((find char "il.:/'`" :test #'char=) 3.5)
+    ((find char "fjrt" :test #'char=) 4.5)
+    ((find char "MW" :test #'char=) 9.0)
+    ((find char "IJ" :test #'char=) 4.0)
+    ((upper-case-p char) 7.0)
+    ((digit-char-p char) 6.0)
+    ((find char "mw" :test #'char=) 7.0)
+    ((find char "-_/" :test #'char=) 4.5)
+    ((lower-case-p char) 5.5)
+    (t 6.0)))
+
+(defun badge-text-width (text)
+  (loop for char across text
+        sum (badge-char-width char)))
+
+(defun badge-section-width (text)
+  (let* ((content-width (badge-text-width text))
+         (total-width (+ content-width (* 2 +badge-side-padding+))))
+    (round (max total-width +badge-min-section-width+))))
+
+(defun format-position (value)
+  (let* ((number (float value 1.0d0))
+         (string (format nil "~,1F" number))
+         (length (length string)))
+    (if (and (>= length 3)
+             (char= (char string (- length 2)) #\.)
+             (char= (char string (1- length)) #\0))
+        (subseq string 0 (- length 2))
+        string)))
+
+(defun compose-badge (label-text value-text value-color)
+  (let* ((label-width (badge-section-width label-text))
+         (value-width (badge-section-width value-text))
+         (total-width (+ label-width value-width))
+         (label-center (format-position (/ label-width 2)))
+         (value-center (format-position (+ label-width (/ value-width 2)))))
+    (format nil
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"~D\" height=\"20\"><linearGradient id=\"b\" x2=\"0\" y2=\"100%\"><stop offset=\"0\" stop-color=\"#bbb\" stop-opacity=\".1\"/><stop offset=\"1\" stop-opacity=\".1\"/></linearGradient><mask id=\"a\"><rect width=\"~D\" height=\"20\" rx=\"3\" fill=\"#fff\"/></mask><g mask=\"url(#a)\"><path fill=\"#555\" d=\"M0 0h~Dv20H0z\"/><path fill=\"~A\" d=\"M~D 0h~Dv20H~Dz\"/><path fill=\"url(#b)\" d=\"M0 0h~Dv20H0z\"/></g><g fill=\"#fff\" text-anchor=\"middle\" font-family=\"DejaVu Sans,Verdana,Geneva,sans-serif\" font-size=\"11\"><text x=\"~A\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">~A</text><text x=\"~A\" y=\"14\">~A</text><text x=\"~A\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">~A</text><text x=\"~A\" y=\"14\">~A</text></g></svg>"
+            total-width
+            total-width
+            label-width
+            value-color
+            label-width
+            value-width
+            label-width
+            total-width
+            label-center
+            label-text
+            label-center
+            label-text
+            value-center
+            value-text
+            value-center
+            value-text)))
+
 
 (defun make-versioned-badge (dist-name version)
-  (format nil
-          "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"137\" height=\"20\"><linearGradient id=\"b\" x2=\"0\" y2=\"100%\"><stop offset=\"0\" stop-color=\"#bbb\" stop-opacity=\".1\"/><stop offset=\"1\" stop-opacity=\".1\"/></linearGradient><mask id=\"a\"><rect width=\"137\" height=\"20\" rx=\"3\" fill=\"#fff\"/></mask><g mask=\"url(#a)\"><path fill=\"#555\" d=\"M0 0h61v20H0z\"/><path fill=\"#007ec6\" d=\"M61 0h76v20H61z\"/><path fill=\"url(#b)\" d=\"M0 0h137v20H0z\"/></g><g fill=\"#fff\" text-anchor=\"middle\" font-family=\"DejaVu Sans,Verdana,Geneva,sans-serif\" font-size=\"11\"><text x=\"30.5\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">~@(~A~)</text><text x=\"30.5\" y=\"14\">~:*~@(~A~)</text><text x=\"98\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">~A</text><text x=\"98\" y=\"14\">~:*~A</text></g></svg>"
-          dist-name
-          version))
+  (compose-badge (format nil "~@(~A~)" dist-name)
+                 (format nil "~A" version)
+                 "#007ec6"))
 
 
 (defun make-missing-badge (dist-name)
-  (format nil
-          "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"144\" height=\"20\"><linearGradient id=\"b\" x2=\"0\" y2=\"100%\"><stop offset=\"0\" stop-color=\"#bbb\" stop-opacity=\".1\"/><stop offset=\"1\" stop-opacity=\".1\"/></linearGradient><mask id=\"a\"><rect width=\"144\" height=\"20\" rx=\"3\" fill=\"#fff\"/></mask><g mask=\"url(#a)\"><path fill=\"#555\" d=\"M0 0h61v20H0z\"/><path fill=\"#9f9f9f\" d=\"M61 0h83v20H61z\"/><path fill=\"url(#b)\" d=\"M0 0h144v20H0z\"/></g><g fill=\"#fff\" text-anchor=\"middle\" font-family=\"DejaVu Sans,Verdana,Geneva,sans-serif\" font-size=\"11\"><text x=\"30.5\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">~@(~A~)</text><text x=\"30.5\" y=\"14\">~:*~@(~A~)</text><text x=\"101.5\" y=\"15\" fill=\"#010101\" fill-opacity=\".3\">not available</text><text x=\"101.5\" y=\"14\">not available</text></g></svg>"
-          dist-name))
+  (compose-badge (format nil "~@(~A~)" dist-name)
+                 "not available"
+                 "#9f9f9f"))
 
 (defun badge-svg (project-name)
   (let* ((dist (common-dist))

--- a/src/badges.lisp
+++ b/src/badges.lisp
@@ -22,8 +22,12 @@
        version))
     (t (princ-to-string version))))
 
-(defparameter +badge-side-padding+ 7)
-(defparameter +badge-min-section-width+ 32)
+(defconstant +badge-side-padding+ 7
+  "Padding applied to both sides of each badge section.")
+(defconstant +badge-min-section-width+ 32
+  "Minimum width to keep the layout readable.")
+(defconstant +badge-value-extra-padding+ 4
+  "Extra whitespace around the values.")
 
 (defun badge-char-width (char)
   (cond
@@ -59,7 +63,8 @@
 
 (defun compose-badge (label-text value-text value-color)
   (let* ((label-width (badge-section-width label-text))
-         (value-width (badge-section-width value-text))
+         (value-width-base (badge-section-width value-text))
+         (value-width (+ value-width-base +badge-value-extra-padding+))
          (total-width (+ label-width value-width))
          (label-center (format-position (/ label-width 2)))
          (value-center (format-position (+ label-width (/ value-width 2)))))


### PR DESCRIPTION
The badges for projects were a bit squished #320 

With this change, they no longer are:

<img width="161" height="23" alt="Untitled" src="https://github.com/user-attachments/assets/1e17e666-46b1-43a9-ae2b-f16f96a97777" />
