### PR TITLE
Previously fixed, but forgot these two

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -2,6 +2,11 @@
  ChangeLog
 ===========
 
+1.28.5 (2025-10-06)
+====================
+
+* Unified environment variable names for Postgres, part 2
+
 1.28.4 (2025-09-29)
 ====================
 

--- a/common-services.yml
+++ b/common-services.yml
@@ -86,7 +86,7 @@ services:
     restart: always
     environment:
       POSTGRES_USER: ultralisp
-      POSTGRES_PASS: ultralisp
+      POSTGRES_PASSWORD: ultralisp
     ports:
       - "127.0.0.1:5432:5432"
     volumes:
@@ -111,7 +111,7 @@ services:
     restart: always
     environment:
       POSTGRES_USER: ultralisp
-      POSTGRES_PASS: ultralisp
+      POSTGRES_PASSWORD: ultralisp
     ports:
       - "127.0.0.1:5433:5432"
     volumes:


### PR DESCRIPTION
Passwords for Postgres were unified to use POSTGRES_PASSWORD instead of POSTGRES_PASS, but these two instances were left behind.